### PR TITLE
Stabilize timeline playback and synchronize GES edits

### DIFF
--- a/rust/src/editor/.main.rs
+++ b/rust/src/editor/.main.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[path = "mod.rs"]
 mod editor;
 #[path = "../gpui_inspector.rs"]

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -356,7 +356,6 @@ impl Editor {
         self.status = Some(format!("Pasted {count} clip{}.", plural_suffix(count)));
         timeline.save(&self.global_settings.project_root);
 
-        self.load_timeline_position_with_options(playhead, true);
         self.schedule_active_timeline_waveforms(cx);
     }
 
@@ -379,12 +378,8 @@ impl Editor {
         self.properties.transform_input_clip_id = None;
         self.properties.text_input_clip_id = None;
 
-        let clips_empty = timeline.data.clips.is_empty();
-        let playhead = timeline.playhead;
-        if clips_empty {
+        if timeline.data.clips.is_empty() {
             timeline.playhead = TimelineTime::ZERO;
-        } else {
-            self.load_timeline_position_with_options(playhead, true);
         }
         let Some(timeline) = self.timeline.as_ref() else {
             return;
@@ -546,7 +541,6 @@ impl Editor {
         let Some(timeline) = self.timeline.as_mut() else {
             return;
         };
-        let playhead = timeline.playhead;
         timeline.record_editing_history();
         edit_and_rebuild_timeline(
             &mut self.preview,
@@ -556,15 +550,12 @@ impl Editor {
         )
         .expect("toggling track visibility cannot be rejected");
         timeline.save(&self.global_settings.project_root);
-
-        self.load_timeline_position_with_options(playhead, true);
     }
 
     pub(super) fn toggle_track_mute(&mut self, track_id: Ulid) {
         let Some(timeline) = self.timeline.as_mut() else {
             return;
         };
-        let playhead = timeline.playhead;
         timeline.record_editing_history();
         edit_and_rebuild_timeline(
             &mut self.preview,
@@ -574,8 +565,6 @@ impl Editor {
         )
         .expect("toggling track mute cannot be rejected");
         timeline.save(&self.global_settings.project_root);
-
-        self.load_timeline_position_with_options(playhead, true);
     }
 
     pub(super) fn move_track(&mut self, track_id: Ulid, direction: i8) {
@@ -600,7 +589,7 @@ impl Editor {
         let Some(target) = target else {
             return;
         };
-        let playhead = timeline.playhead;
+
         timeline.record_editing_history();
         edit_and_rebuild_timeline(
             &mut self.preview,
@@ -610,8 +599,6 @@ impl Editor {
         )
         .expect("moving a track cannot be rejected");
         timeline.save(&self.global_settings.project_root);
-
-        self.load_timeline_position_with_options(playhead, true);
     }
 
     pub(super) fn delete_track(&mut self, track_id: Ulid) {
@@ -629,7 +616,6 @@ impl Editor {
         if timeline.data.tracks[index].locked {
             return;
         }
-        let playhead = timeline.playhead;
         timeline.record_editing_history();
         edit_and_rebuild_timeline(
             &mut self.preview,
@@ -661,8 +647,6 @@ impl Editor {
                 .map(Clip::id);
         }
         timeline.save(&self.global_settings.project_root);
-
-        self.load_timeline_position_with_options(playhead, true);
     }
 
     pub(super) fn select_only_clip(&mut self, clip_id: Option<Ulid>) {
@@ -784,24 +768,14 @@ impl Editor {
                     .find(|clip| timeline.interaction.selected_clip_ids.contains(&clip.id()))
                     .map(Clip::id)
             });
-        let has_clips = !timeline.data.clips.is_empty();
-        let playhead = timeline.playhead;
         self.properties.transform_input_clip_id = None;
         self.properties.text_input_clip_id = None;
-        if has_clips {
-            self.load_timeline_position_with_options(playhead, true);
+        if !timeline.data.clips.is_empty() {
+            load_timeline_position_with_options(&mut self.preview, timeline, timeline.playhead);
         }
         let Some(timeline) = self.timeline.as_ref() else {
             return;
         };
-        timeline.save(&self.global_settings.project_root);
-    }
-
-    pub(super) fn save_timeline_playhead(&mut self) {
-        let Some(timeline) = self.timeline.as_mut() else {
-            return;
-        };
-        timeline.capture_playhead(&self.global_settings.project_root);
         timeline.save(&self.global_settings.project_root);
     }
 

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1,4 +1,5 @@
 use super::*;
+use gstreamer_editing_services::prelude::TimelineExt as _;
 use std::path::Path;
 
 #[derive(Clone)]
@@ -232,19 +233,9 @@ impl TimelineRuntimeState {
             preview,
             project_root,
             self,
-            EditAction::RemoveClips {
-                clip_ids: removed_clip_ids,
-                close_track_gaps: false,
-            },
-        )
-        .expect("removing clips cannot be rejected");
-        edit_and_rebuild_timeline(
-            preview,
-            project_root,
-            self,
-            EditAction::AddClips {
-                clips: split_clips,
-                assets: Vec::new(),
+            EditAction::SplitClips {
+                removed_clips: removed_clip_ids,
+                added_clips: split_clips,
             },
         )
         .expect("split clip placements were validated before recording history");
@@ -916,6 +907,10 @@ pub(super) enum EditAction {
         clip_ids: HashSet<Ulid>,
         close_track_gaps: bool,
     },
+    SplitClips {
+        removed_clips: HashSet<Ulid>,
+        added_clips: Vec<Clip>,
+    },
     UpdateClip {
         clip: Clip,
     },
@@ -981,6 +976,7 @@ impl EditAction {
         match self {
             Self::AddClips { .. } => "AddClips",
             Self::RemoveClips { .. } => "RemoveClips",
+            Self::SplitClips { .. } => "SplitClips",
             Self::MoveClips { .. } => "MoveClips",
             Self::UpdateClip { .. } => "UpdateClip",
             Self::SetVideoProperties { .. } => "SetVideoProperties",
@@ -1057,12 +1053,11 @@ pub(super) fn edit_timeline(
             updated_timeline.assets.extend(assets);
             validate_clips_placements(&updated_timeline, &clips)?;
             updated_timeline.clips.extend(clips.iter().cloned());
-            ges_add_clips(
-                timeline.video_backend.ges_timeline(),
-                &updated_timeline,
-                project_root,
-                &clips,
-            )?;
+            let ges = timeline.video_backend.ges_timeline();
+            ges_add_clips(ges, &updated_timeline, project_root, &clips)?;
+            if !ges.commit() {
+                anyhow::bail!("GStreamer could not commit the added clips.");
+            }
             timeline.data = updated_timeline;
             return Ok(false);
         }
@@ -1089,12 +1084,32 @@ pub(super) fn edit_timeline(
                 })
                 .map(|clip| (clip.id(), clip.track_id(), clip.timeline_start()))
                 .collect::<Vec<_>>();
-            ges_remove_clips(timeline.video_backend.ges_timeline(), &clip_ids)?;
-            ges_move_clips(
-                timeline.video_backend.ges_timeline(),
-                &updated_timeline,
-                &ripple_placements,
-            )?;
+            let ges = timeline.video_backend.ges_timeline();
+            ges_remove_clips(ges, &clip_ids)?;
+            ges_move_clips(ges, &updated_timeline, &ripple_placements)?;
+            if !ges.commit_sync() {
+                anyhow::bail!("GStreamer could not commit the removed clips.");
+            }
+            timeline.data = updated_timeline;
+            return Ok(false);
+        }
+        EditAction::SplitClips {
+            removed_clips,
+            added_clips,
+        } => {
+            let mut updated_timeline = timeline.data.clone();
+            updated_timeline
+                .clips
+                .retain(|clip| !removed_clips.contains(&clip.id()));
+            validate_clips_placements(&updated_timeline, &added_clips)?;
+            updated_timeline.clips.extend(added_clips.iter().cloned());
+
+            let ges = timeline.video_backend.ges_timeline();
+            ges_remove_clips(ges, &removed_clips)?;
+            ges_add_clips(ges, &updated_timeline, project_root, &added_clips)?;
+            if !ges.commit_sync() {
+                anyhow::bail!("GStreamer could not commit the split clips.");
+            }
             timeline.data = updated_timeline;
             return Ok(false);
         }
@@ -1108,11 +1123,11 @@ pub(super) fn edit_timeline(
                 .data
                 .validate_clip_move_placements(&placements, &moved_clip_ids)?;
 
-            ges_move_clips(
-                timeline.video_backend.ges_timeline(),
-                &timeline.data,
-                &placements,
-            )?;
+            let ges = timeline.video_backend.ges_timeline();
+            ges_move_clips(ges, &timeline.data, &placements)?;
+            if !ges.commit() {
+                anyhow::bail!("GStreamer could not commit the moved clips.");
+            }
 
             for (clip_id, track_id, start) in placements {
                 if let Some(clip) = timeline.data.clip_mut(clip_id) {
@@ -1161,15 +1176,18 @@ pub(super) fn edit_timeline(
             updated_timeline.clips.insert(clip_index, clip.clone());
 
             let clip_ids = HashSet::from([clip_id]);
-            ges_remove_clips(timeline.video_backend.ges_timeline(), &clip_ids)
-                .expect("updated clip must be removable from GES");
+            let ges = timeline.video_backend.ges_timeline();
+            ges_remove_clips(ges, &clip_ids).expect("updated clip must be removable from GES");
             ges_add_clips(
-                timeline.video_backend.ges_timeline(),
+                ges,
                 &updated_timeline,
                 project_root,
                 std::slice::from_ref(&clip),
             )
             .expect("updated clip must be addable to GES");
+            if !ges.commit_sync() {
+                anyhow::bail!("GStreamer could not commit the updated clip.");
+            }
 
             timeline.data = updated_timeline;
             return Ok(false);
@@ -1390,9 +1408,6 @@ fn ges_move_clips(
     {
         anyhow::bail!("could not update the GES timeline background duration");
     }
-    if !ges.commit() {
-        anyhow::bail!("GStreamer could not commit the moved clips.");
-    }
     Ok(())
 }
 
@@ -1492,9 +1507,6 @@ fn ges_remove_clips(
         {
             anyhow::bail!("could not update the GES timeline background duration");
         }
-    }
-    if !ges.commit() {
-        anyhow::bail!("GStreamer could not commit the removed clips.");
     }
     Ok(())
 }
@@ -1686,9 +1698,6 @@ fn ges_add_clips(
         background_layer.add_clip(&background).map_err(|error| {
             anyhow::anyhow!("could not add the GES timeline background: {error}")
         })?;
-    }
-    if !ges.commit() {
-        anyhow::bail!("GStreamer could not commit the added clips.");
     }
     Ok(())
 }

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1014,23 +1014,22 @@ pub(super) fn edit_and_rebuild_timeline(
     let rebuild_timeline = edit_timeline(timeline, project_root, action)?;
     eprintln!("edit_timeline {action_type} - {:?}", t.elapsed());
     if !rebuild_timeline {
-        data_parity_check(&timeline, &timeline.ges_timeline)?;
+        data_parity_check(timeline, timeline.video_backend.ges_timeline())?;
         return Ok(());
     }
     eprintln!("rebuild the timeline is slow");
-    let volume = match &preview.target {
-        PreviewTarget::Timeline(video) => video.volume(),
-        _ => 1.0,
-    };
-    if let Some(video) = preview.target.video() {
-        video.set_paused(true);
-    }
+    let volume = timeline.video_backend.playback().volume();
+
+    timeline.video_backend.playback().set_paused(true);
+
     preview.target = PreviewTarget::None;
-    timeline.ges_timeline = build_ges_timeline(
+    let ges_timeline = build_ges_timeline(
         &timeline.data,
         project_root,
         export::ExportOptions::from_timeline(&timeline.data),
     )?;
+
+    timeline.video_backend = TimelineVideoBackend::new(ges_timeline)?;
     timeline.playhead = timeline
         .playhead
         .clamp(TimelineTime::ZERO, timeline.data.content_duration());
@@ -1038,12 +1037,12 @@ pub(super) fn edit_and_rebuild_timeline(
         return Ok(());
     }
 
-    let mut video = create_timeline_video(&timeline.ges_timeline).unwrap();
+    let video = timeline.video_backend.playback_mut();
     video.set_volume(volume);
     video.set_muted(volume <= f64::EPSILON);
     let _ = video.seek(timeline.data.duration(timeline.playhead), true);
-    preview.target = PreviewTarget::Timeline(video);
-    data_parity_check(&timeline, &timeline.ges_timeline)?;
+    preview.target = PreviewTarget::Timeline;
+    data_parity_check(timeline, timeline.video_backend.ges_timeline())?;
     Ok(())
 }
 
@@ -1059,7 +1058,7 @@ pub(super) fn edit_timeline(
             validate_clips_placements(&updated_timeline, &clips)?;
             updated_timeline.clips.extend(clips.iter().cloned());
             ges_add_clips(
-                &timeline.ges_timeline,
+                timeline.video_backend.ges_timeline(),
                 &updated_timeline,
                 project_root,
                 &clips,
@@ -1090,9 +1089,9 @@ pub(super) fn edit_timeline(
                 })
                 .map(|clip| (clip.id(), clip.track_id(), clip.timeline_start()))
                 .collect::<Vec<_>>();
-            ges_remove_clips(&timeline.ges_timeline, &clip_ids)?;
+            ges_remove_clips(timeline.video_backend.ges_timeline(), &clip_ids)?;
             ges_move_clips(
-                &timeline.ges_timeline,
+                timeline.video_backend.ges_timeline(),
                 &updated_timeline,
                 &ripple_placements,
             )?;
@@ -1109,7 +1108,11 @@ pub(super) fn edit_timeline(
                 .data
                 .validate_clip_move_placements(&placements, &moved_clip_ids)?;
 
-            ges_move_clips(&timeline.ges_timeline, &timeline.data, &placements)?;
+            ges_move_clips(
+                timeline.video_backend.ges_timeline(),
+                &timeline.data,
+                &placements,
+            )?;
 
             for (clip_id, track_id, start) in placements {
                 if let Some(clip) = timeline.data.clip_mut(clip_id) {
@@ -1140,8 +1143,12 @@ pub(super) fn edit_timeline(
                         .track(updated.track_id)
                         .is_some_and(|track| track.visible)
                 {
-                    ges_change_text_clip(&timeline.ges_timeline, clip_id, &updated.properties)
-                        .expect("updated text clip properties must be applicable to GES");
+                    ges_change_text_clip(
+                        timeline.video_backend.ges_timeline(),
+                        clip_id,
+                        &updated.properties,
+                    )
+                    .expect("updated text clip properties must be applicable to GES");
                 }
                 timeline.data.clips[clip_index] = clip;
                 return Ok(false);
@@ -1154,10 +1161,10 @@ pub(super) fn edit_timeline(
             updated_timeline.clips.insert(clip_index, clip.clone());
 
             let clip_ids = HashSet::from([clip_id]);
-            ges_remove_clips(&timeline.ges_timeline, &clip_ids)
+            ges_remove_clips(timeline.video_backend.ges_timeline(), &clip_ids)
                 .expect("updated clip must be removable from GES");
             ges_add_clips(
-                &timeline.ges_timeline,
+                timeline.video_backend.ges_timeline(),
                 &updated_timeline,
                 project_root,
                 std::slice::from_ref(&clip),
@@ -1184,7 +1191,11 @@ pub(super) fn edit_timeline(
             if let Some(Clip::Text(clip)) = timeline.data.clip_mut(clip_id) {
                 clip.properties = properties;
                 // change the text of a text clip
-                ges_change_text_clip(&timeline.ges_timeline, clip_id, &clip.properties)?;
+                ges_change_text_clip(
+                    timeline.video_backend.ges_timeline(),
+                    clip_id,
+                    &clip.properties,
+                )?;
             }
             return Ok(false); // should not rebuild timeline
         }

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1036,7 +1036,7 @@ pub(super) fn edit_and_rebuild_timeline(
     let video = timeline.video_backend.playback_mut();
     video.set_volume(volume);
     video.set_muted(volume <= f64::EPSILON);
-    let _ = video.seek(timeline.data.duration(timeline.playhead), true);
+    let _ = video.seek(timeline.data.duration(timeline.playhead));
     preview.target = PreviewTarget::Timeline;
     data_parity_check(timeline, timeline.video_backend.ges_timeline())?;
     Ok(())

--- a/rust/src/editor/editing.test.rs
+++ b/rust/src/editor/editing.test.rs
@@ -420,6 +420,65 @@ fn removes_ges_clip_and_ripples_surviving_clips() {
 }
 
 #[test]
+fn splits_ges_clip_with_one_edit_action() {
+    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
+    gstreamer_editing_services::init().unwrap();
+    let track_id = ulid(3);
+    let original_clip_id = ulid(10);
+    let original_clip = Clip::Text(TextClip {
+        id: original_clip_id,
+        track_id,
+        timeline_start: TimelineTime::ZERO,
+        length: Duration::from_secs(4),
+        properties: TextClipProperties::default(),
+    });
+    let project = TimelineSerialization {
+        tracks: vec![Track {
+            id: track_id,
+            name: "Text 1".to_string(),
+            kind: TrackKind::Text,
+            locked: false,
+            muted: false,
+            visible: true,
+        }],
+        clips: vec![original_clip.clone()],
+        ..TimelineSerialization::default()
+    };
+    let ges = build_ges_timeline(
+        &project,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        export::ExportOptions::from_timeline(&project),
+    )
+    .unwrap();
+    let mut runtime =
+        TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone()).unwrap();
+    let split_position = TimelineTime::from_frames(60);
+    let (left, right) = original_clip
+        .split_at(split_position, runtime.data.settings.frame_rate)
+        .unwrap();
+    let right_clip_id = right.id();
+
+    edit_timeline(
+        &mut runtime,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        EditAction::SplitClips {
+            removed_clips: HashSet::from([original_clip_id]),
+            added_clips: vec![left, right],
+        },
+    )
+    .unwrap();
+
+    assert!(runtime.data.clip(original_clip_id).is_some());
+    assert!(runtime.data.clip(right_clip_id).is_some());
+    assert_eq!(runtime.data.clips.len(), 2);
+    assert_eq!(
+        runtime.data.content_duration(),
+        TimelineTime::from_frames(120)
+    );
+    data_parity_check(&runtime, &ges).unwrap();
+}
+
+#[test]
 fn detects_timeline_and_ges_data_divergence() {
     let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();

--- a/rust/src/editor/editing.test.rs
+++ b/rust/src/editor/editing.test.rs
@@ -385,7 +385,8 @@ fn removes_ges_clip_and_ripples_surviving_clips() {
         export::ExportOptions::from_timeline(&project),
     )
     .unwrap();
-    let mut runtime = TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone());
+    let mut runtime =
+        TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone()).unwrap();
 
     edit_timeline(
         &mut runtime,
@@ -448,7 +449,8 @@ fn detects_timeline_and_ges_data_divergence() {
         export::ExportOptions::from_timeline(&project),
     )
     .unwrap();
-    let mut runtime = TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone());
+    let mut runtime =
+        TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone()).unwrap();
 
     let rendered = ges
         .layers()

--- a/rust/src/editor/editor.rs
+++ b/rust/src/editor/editor.rs
@@ -132,14 +132,14 @@ impl Editor {
             event_bus,
             context_menu: ContextMenu::None,
         };
-        if let Some(timeline) = editor.timeline.as_ref()
+        if let Some(timeline) = editor.timeline.as_mut()
             && !timeline.data.clips.is_empty()
         {
             match create_timeline_video(&timeline.ges_timeline) {
                 Ok(video) => {
                     let playhead = timeline.playhead;
                     editor.preview.target = PreviewTarget::Timeline(video);
-                    editor.load_timeline_position_with_options(playhead, true);
+                    load_timeline_position_with_options(&mut editor.preview, timeline, playhead);
                 }
                 Err(error) => eprintln!("{error}"),
             }

--- a/rust/src/editor/editor.rs
+++ b/rust/src/editor/editor.rs
@@ -48,11 +48,7 @@ impl Editor {
                     export::ExportOptions::from_timeline(&timeline_data),
                 )
                 .unwrap();
-                Some(TimelineRuntimeState::new(
-                    timeline_path,
-                    timeline_data,
-                    ges_timeline,
-                ))
+                Some(TimelineRuntimeState::new(timeline_path, timeline_data, ges_timeline).unwrap())
             })()
         };
         // load timeline end
@@ -135,14 +131,9 @@ impl Editor {
         if let Some(timeline) = editor.timeline.as_mut()
             && !timeline.data.clips.is_empty()
         {
-            match create_timeline_video(&timeline.ges_timeline) {
-                Ok(video) => {
-                    let playhead = timeline.playhead;
-                    editor.preview.target = PreviewTarget::Timeline(video);
-                    load_timeline_position_with_options(&mut editor.preview, timeline, playhead);
-                }
-                Err(error) => eprintln!("{error}"),
-            }
+            let playhead = timeline.playhead;
+            editor.preview.target = PreviewTarget::Timeline;
+            load_timeline_position_with_options(&mut editor.preview, timeline, playhead);
         }
         editor.schedule_project_waveforms(cx);
         editor
@@ -284,9 +275,11 @@ fn start_updates(cx: &mut Context<Editor>) {
             cx.background_executor().timer(IDLE_UPDATE_INTERVAL).await;
             let result = editor.update(cx, |editor, cx| {
                 let preview_playing = match &editor.preview.target {
-                    PreviewTarget::Timeline(video) | PreviewTarget::VideoFile(_, video) => {
-                        !video.paused()
-                    }
+                    PreviewTarget::Timeline => editor
+                        .timeline
+                        .as_ref()
+                        .is_some_and(|timeline| !timeline.video_backend.playback().paused()),
+                    PreviewTarget::VideoFile(_, video) => !video.paused(),
                     PreviewTarget::AudioFile(_, audio) => audio.playing(),
                     _ => false,
                 };

--- a/rust/src/editor/explorer.rs
+++ b/rust/src/editor/explorer.rs
@@ -16,7 +16,7 @@ use crate::{
         timeline_document,
         track::TrackKind,
     },
-    video::VideoBackend,
+    video::FileVideoBackend,
 };
 use gpui::{
     AppContext as _, Context, CursorStyle, Entity, InteractiveElement, IntoElement, MouseButton,

--- a/rust/src/editor/explorer_file_entry.rs
+++ b/rust/src/editor/explorer_file_entry.rs
@@ -1,6 +1,7 @@
 use crate::editor::explorer_drag::AssetBeingDragged;
 
 use super::*;
+use anyhow::Context as _;
 use std::{collections::HashSet, fs, path::Path};
 use url::Url;
 
@@ -491,9 +492,8 @@ impl Editor {
             return;
         }
 
-        let video = FileVideoBackend::open(&url).map_err(|error| {
-            anyhow::anyhow!("Could not preview {}: {error}", source_path.display())
-        });
+        let video = FileVideoBackend::open(&url)
+            .with_context(|| format!("Could not preview {}", source_path.display()));
 
         let still_requested = matches!(
             self.explorer.selected_file.as_ref(),

--- a/rust/src/editor/explorer_file_entry.rs
+++ b/rust/src/editor/explorer_file_entry.rs
@@ -423,6 +423,9 @@ impl Editor {
         self.explorer.selected_file = Some(relative_path.clone());
 
         if is_image || is_video || is_audio {
+            if let Some(video) = self.active_video() {
+                video.set_paused(true);
+            }
             self.preview.target = match (is_video, is_audio) {
                 (true, _) | (_, true) => PreviewTarget::None,
                 _ => PreviewTarget::ImageFile(relative_path.clone()),
@@ -485,7 +488,7 @@ impl Editor {
             return;
         }
 
-        let video = VideoBackend::open(&url).map_err(|error| {
+        let video = FileVideoBackend::open(&url).map_err(|error| {
             anyhow::anyhow!("Could not preview {}: {error}", source_path.display())
         });
 

--- a/rust/src/editor/explorer_file_entry.rs
+++ b/rust/src/editor/explorer_file_entry.rs
@@ -67,9 +67,12 @@ impl Editor {
                                 eprintln!("{error}");
                             }
                         }
-                        FileTreeEntryKind::Timeline => editor
-                            .open_timeline(path.clone(), cx)
-                            .expect("open_timeline failed"),
+                        FileTreeEntryKind::Timeline => {
+                            let err = editor.open_timeline(path.clone(), cx);
+                            if let Err(error) = err {
+                                eprintln!("{error:?}");
+                            }
+                        }
                         FileTreeEntryKind::Video
                         | FileTreeEntryKind::Image
                         | FileTreeEntryKind::Audio

--- a/rust/src/editor/explorer_file_menu.rs
+++ b/rust/src/editor/explorer_file_menu.rs
@@ -156,7 +156,7 @@ impl Editor {
                     *path = new_path;
                 }
             }
-            PreviewTarget::None | PreviewTarget::Timeline(_) => {}
+            PreviewTarget::None | PreviewTarget::Timeline => {}
         }
 
         let renamed_active_timeline = self

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -1,4 +1,7 @@
-use crate::{editor::explorer_drag::AssetBeingDragged, video::VideoBackend};
+use crate::{
+    editor::{explorer_drag::AssetBeingDragged, preview::load_timeline_position_with_options},
+    video::VideoBackend,
+};
 use gpui::{
     App, Bounds, Context, CursorStyle, Entity, EventEmitter, FocusHandle, KeyBinding, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, PathPromptOptions, Pixels, Render,
@@ -277,18 +280,17 @@ impl Editor {
             .is_some_and(|timeline| timeline.path == relative_path)
         {
             self.select_only_clip(None);
-            let timeline = self.timeline.as_ref().expect("timeline was checked above");
+            let timeline = self.timeline.as_mut().expect("timeline was checked above");
             let playhead = timeline.playhead;
             if !timeline.data.clips.is_empty() {
-                self.load_timeline_position_with_options(playhead, true);
+                load_timeline_position_with_options(&mut self.preview, timeline, playhead);
             }
             self.explorer.selected_file = Some(relative_path);
             cx.notify();
             return Ok(());
         }
         let path = self.global_settings.project_root.join(&relative_path);
-        let timeline = TimelineSerialization::load(&path)
-            .map_err(|error| anyhow::anyhow!("Could not open timeline: {error}"))?;
+        let timeline = TimelineSerialization::load(&path)?;
         if let Some(timeline) = self.timeline.as_ref() {
             timeline.save(&self.global_settings.project_root);
         }
@@ -365,13 +367,13 @@ impl Editor {
         self.dismiss_context_menu();
         self.explorer
             .refresh_file_tree(&self.global_settings.project_root)?;
-        if let Some(timeline) = self.timeline.as_ref()
+        if let Some(timeline) = self.timeline.as_mut()
             && !timeline.data.clips.is_empty()
         {
             let playhead = timeline.playhead;
             let video = create_timeline_video(&timeline.ges_timeline)?;
             self.preview.target = PreviewTarget::Timeline(video);
-            self.load_timeline_position_with_options(playhead, true);
+            load_timeline_position_with_options(&mut self.preview, timeline, playhead);
         } else {
             self.preview.target = PreviewTarget::None;
         }

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     editor::{explorer_drag::AssetBeingDragged, preview::load_timeline_position_with_options},
-    video::VideoBackend,
+    video::{FileVideoBackend, VideoBackend},
 };
 use gpui::{
     App, Bounds, Context, CursorStyle, Entity, EventEmitter, FocusHandle, KeyBinding, MouseButton,
@@ -84,7 +84,7 @@ use timeline_clip::{Clip, TextClip, TextClipProperties, VideoClipProperties};
 use timeline_clip_menu::transform_targets;
 use timeline_document::{load_existing_timeline, project_timeline_files};
 use timeline_interactions::{MarqueeSelection, TimelineInteractionState, TimelineTool};
-use timeline_video::create_timeline_video;
+use timeline_video::TimelineVideoBackend;
 use track::{Track, TrackKind};
 use ulid::Ulid;
 use workspace::{GlobalEditorSettings, load_global_editor_settings, save_global_editor_settings};
@@ -350,7 +350,7 @@ impl Editor {
             timeline_path,
             active_timeline,
             ges_timeline,
-        ));
+        )?);
         save_project_local_settings(
             &self.global_settings.project_root,
             self.timeline
@@ -371,8 +371,7 @@ impl Editor {
             && !timeline.data.clips.is_empty()
         {
             let playhead = timeline.playhead;
-            let video = create_timeline_video(&timeline.ges_timeline)?;
-            self.preview.target = PreviewTarget::Timeline(video);
+            self.preview.target = PreviewTarget::Timeline;
             load_timeline_position_with_options(&mut self.preview, timeline, playhead);
         } else {
             self.preview.target = PreviewTarget::None;

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     editor::{explorer_drag::AssetBeingDragged, preview::load_timeline_position_with_options},
     video::{FileVideoBackend, VideoBackend},
 };
+use anyhow::{Context as _, Result};
 use gpui::{
     App, Bounds, Context, CursorStyle, Entity, EventEmitter, FocusHandle, KeyBinding, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, PathPromptOptions, Pixels, Render,
@@ -273,32 +274,35 @@ impl Editor {
         &mut self,
         relative_path: PathBuf,
         cx: &mut Context<Self>,
-    ) -> anyhow::Result<()> {
-        if self
-            .timeline
-            .as_ref()
-            .is_some_and(|timeline| timeline.path == relative_path)
-        {
-            self.select_only_clip(None);
-            let timeline = self.timeline.as_mut().expect("timeline was checked above");
-            let playhead = timeline.playhead;
-            if !timeline.data.clips.is_empty() {
-                load_timeline_position_with_options(&mut self.preview, timeline, playhead);
+    ) -> Result<()> {
+        (|| -> Result<()> {
+            if self
+                .timeline
+                .as_ref()
+                .is_some_and(|timeline| timeline.path == relative_path)
+            {
+                self.select_only_clip(None);
+                let timeline = self.timeline.as_mut().expect("timeline was checked above");
+                let playhead = timeline.playhead;
+                if !timeline.data.clips.is_empty() {
+                    load_timeline_position_with_options(&mut self.preview, timeline, playhead);
+                }
+                self.explorer.selected_file = Some(relative_path);
+                cx.notify();
+                return Ok(());
             }
-            self.explorer.selected_file = Some(relative_path);
-            cx.notify();
-            return Ok(());
-        }
-        let path = self.global_settings.project_root.join(&relative_path);
-        let timeline = TimelineSerialization::load(&path)?;
-        if let Some(timeline) = self.timeline.as_ref() {
-            timeline.save(&self.global_settings.project_root);
-        }
-        self.activate_timeline(relative_path.clone(), timeline, cx)?;
-        self.select_only_clip(None);
-        self.explorer.selected_file = Some(relative_path.clone());
-        self.status = Some(format!("Opened {}", relative_path.display()));
-        Ok(())
+            let path = self.global_settings.project_root.join(&relative_path);
+            let timeline = TimelineSerialization::load(&path)?;
+            if let Some(timeline) = self.timeline.as_ref() {
+                timeline.save(&self.global_settings.project_root);
+            }
+            self.activate_timeline(relative_path.clone(), timeline, cx)?;
+            self.select_only_clip(None);
+            self.explorer.selected_file = Some(relative_path.clone());
+            self.status = Some(format!("Opened {}", relative_path.display()));
+            Ok(())
+        })()
+        .context("open_timeline failed")
     }
 
     /// Saves the current timeline, switches to a freshly created one, and reveals it in
@@ -333,51 +337,54 @@ impl Editor {
         timeline_path: PathBuf,
         active_timeline: TimelineSerialization,
         cx: &mut Context<Self>,
-    ) -> anyhow::Result<()> {
-        self.preview.volume_control_open = false;
-        self.preview.is_scrubbing = false;
-        self.preview.is_adjusting_volume = false;
-        self.preview.last_scrub_seek = None;
-        self.preview.timeline_drag = None;
-        self.properties.transform_input_clip_id = None;
-        self.properties.text_input_clip_id = None;
-        let ges_timeline = build_ges_timeline(
-            &active_timeline,
-            &self.global_settings.project_root,
-            export::ExportOptions::from_timeline(&active_timeline),
-        )?;
-        self.timeline = Some(TimelineRuntimeState::new(
-            timeline_path,
-            active_timeline,
-            ges_timeline,
-        )?);
-        save_project_local_settings(
-            &self.global_settings.project_root,
-            self.timeline
-                .as_ref()
-                .map(|timeline| timeline.path.as_path()),
-        )?;
-        self.explorer.search_query = None;
-        self.explorer.search_results.clear();
-        self.explorer.search_pending = false;
-        self.explorer
-            .filter
-            .update(cx, |filter, cx| filter.clear(cx));
-        self.explorer.selected_file = self.timeline.as_ref().map(|timeline| timeline.path.clone());
-        self.dismiss_context_menu();
-        self.explorer
-            .refresh_file_tree(&self.global_settings.project_root)?;
-        if let Some(timeline) = self.timeline.as_mut()
-            && !timeline.data.clips.is_empty()
-        {
-            let playhead = timeline.playhead;
-            self.preview.target = PreviewTarget::Timeline;
-            load_timeline_position_with_options(&mut self.preview, timeline, playhead);
-        } else {
-            self.preview.target = PreviewTarget::None;
-        }
-        self.schedule_active_timeline_waveforms(cx);
-        Ok(())
+    ) -> Result<()> {
+        (|| -> Result<()> {
+            self.preview.volume_control_open = false;
+            self.preview.is_scrubbing = false;
+            self.preview.is_adjusting_volume = false;
+            self.preview.last_scrub_seek = None;
+            self.preview.timeline_drag = None;
+            self.properties.transform_input_clip_id = None;
+            self.properties.text_input_clip_id = None;
+            let ges_timeline = build_ges_timeline(
+                &active_timeline,
+                &self.global_settings.project_root,
+                export::ExportOptions::from_timeline(&active_timeline),
+            )?;
+            self.timeline = Some(
+                TimelineRuntimeState::new(timeline_path, active_timeline, ges_timeline)
+                    .context("TimelineRuntimeState::new failed")?,
+            );
+            save_project_local_settings(
+                &self.global_settings.project_root,
+                self.timeline
+                    .as_ref()
+                    .map(|timeline| timeline.path.as_path()),
+            )?;
+            self.explorer.search_query = None;
+            self.explorer.search_results.clear();
+            self.explorer.search_pending = false;
+            self.explorer
+                .filter
+                .update(cx, |filter, cx| filter.clear(cx));
+            self.explorer.selected_file =
+                self.timeline.as_ref().map(|timeline| timeline.path.clone());
+            self.dismiss_context_menu();
+            self.explorer
+                .refresh_file_tree(&self.global_settings.project_root)?;
+            if let Some(timeline) = self.timeline.as_mut()
+                && !timeline.data.clips.is_empty()
+            {
+                let playhead = timeline.playhead;
+                self.preview.target = PreviewTarget::Timeline;
+                load_timeline_position_with_options(&mut self.preview, timeline, playhead);
+            } else {
+                self.preview.target = PreviewTarget::None;
+            }
+            self.schedule_active_timeline_waveforms(cx);
+            Ok(())
+        })()
+        .context("activate_timeline failed")
     }
 
     fn schedule_project_waveforms(&mut self, cx: &mut Context<Self>) {

--- a/rust/src/editor/preview.rs
+++ b/rust/src/editor/preview.rs
@@ -25,7 +25,7 @@ pub fn load_timeline_position_with_options(
     let _ = timeline
         .video_backend
         .playback_mut()
-        .seek(timeline.data.duration(position), true);
+        .seek(timeline.data.duration(position));
 }
 
 impl PreviewTarget {
@@ -158,7 +158,7 @@ impl Editor {
         }
         if let PreviewTarget::VideoFile(_, video) = &mut self.preview.target {
             let target = video.duration().mul_f64(fraction as f64);
-            let _ = video.seek(target, true);
+            let _ = video.seek(target);
         }
     }
 }

--- a/rust/src/editor/preview.rs
+++ b/rust/src/editor/preview.rs
@@ -5,8 +5,8 @@ use preview_image::preview_image_file;
 
 pub(super) enum PreviewTarget {
     None,
-    Timeline(VideoBackend),
-    VideoFile(PathBuf, VideoBackend),
+    Timeline,
+    VideoFile(PathBuf, FileVideoBackend),
     AudioFile(PathBuf, AudioBackend),
     ImageFile(PathBuf),
 }
@@ -16,34 +16,21 @@ pub fn load_timeline_position_with_options(
     timeline: &mut TimelineRuntimeState,
     position: TimelineTime,
 ) {
+    preview.target = PreviewTarget::Timeline;
     let duration = timeline.data.content_duration();
     let position = position.clamp(TimelineTime::ZERO, duration);
     timeline.playhead = position;
     preview.timeline_drag = None;
 
-    let video = preview.target.video_mut();
-    if let Some(video) = video {
-        let _ = video.seek(timeline.data.duration(position), true);
-    }
+    let _ = timeline
+        .video_backend
+        .playback_mut()
+        .seek(timeline.data.duration(position), true);
 }
 
 impl PreviewTarget {
     pub(super) fn is_timeline(&self) -> bool {
-        matches!(self, Self::Timeline(_))
-    }
-
-    pub(super) fn video(&self) -> Option<&VideoBackend> {
-        match self {
-            Self::Timeline(video) | Self::VideoFile(_, video) => Some(video),
-            _ => None,
-        }
-    }
-
-    pub(super) fn video_mut(&mut self) -> Option<&mut VideoBackend> {
-        match self {
-            Self::Timeline(video) | Self::VideoFile(_, video) => Some(video),
-            _ => None,
-        }
+        matches!(self, Self::Timeline)
     }
 
     pub(super) fn audio(&self) -> Option<&AudioBackend> {
@@ -73,7 +60,7 @@ impl Editor {
                 .text_color(rgb(MUTED))
                 .child("No preview available")
                 .into_any_element(),
-            PreviewTarget::Timeline(_) => {
+            PreviewTarget::Timeline => {
                 preview_timeline_view(self, origin_x, origin_y, width, height, cx)
             }
             PreviewTarget::VideoFile(_, _) => {
@@ -115,11 +102,12 @@ impl Editor {
 
                 return;
             }
-            PreviewTarget::Timeline(video) => {
-                let is_paused = video.paused();
+            PreviewTarget::Timeline => {
                 let Some(timeline) = self.timeline.as_mut() else {
                     return;
                 };
+                let video = timeline.video_backend.playback();
+                let is_paused = video.paused();
                 if timeline.data.clips.is_empty() {
                     return;
                 }
@@ -130,9 +118,6 @@ impl Editor {
                 } else {
                     timeline.playhead
                 };
-                let PreviewTarget::Timeline(video) = &self.preview.target else {
-                    return;
-                };
                 video.set_paused(!is_paused);
                 load_timeline_position_with_options(&mut self.preview, timeline, start);
             }
@@ -141,9 +126,10 @@ impl Editor {
 }
 
 pub(super) fn update_playback(timeline: &mut TimelineRuntimeState, preview: &mut PreviewState) {
-    let PreviewTarget::Timeline(video) = &preview.target else {
+    if !preview.target.is_timeline() {
         return;
-    };
+    }
+    let video = timeline.video_backend.playback();
     let duration = timeline.data.content_duration();
     timeline.playhead = timeline
         .data
@@ -199,7 +185,7 @@ impl PlaybackViewDelegate for Editor {
 
         match phase {
             DragPhase::Start => {
-                if let Some(video) = self.preview.target.video() {
+                if let Some(video) = self.active_video() {
                     video.set_paused(true);
                 }
                 self.preview.is_scrubbing = true;
@@ -242,23 +228,16 @@ impl PlaybackViewDelegate for Editor {
             DragPhase::End => self.preview.is_adjusting_volume = false,
             DragPhase::Update => {}
         }
-        match &self.preview.target {
-            PreviewTarget::Timeline(video) => {
-                video.set_volume(volume.clamp(0.0, 1.0));
-                video.set_muted(volume.clamp(0.0, 1.0) <= f64::EPSILON);
-            }
-            PreviewTarget::VideoFile(_, video) => {
-                video.set_volume(volume.clamp(0.0, 1.0));
-                video.set_muted(volume.clamp(0.0, 1.0) <= f64::EPSILON);
-            }
-            _ => {}
+        if let Some(video) = self.active_video() {
+            video.set_volume(volume.clamp(0.0, 1.0));
+            video.set_muted(volume.clamp(0.0, 1.0) <= f64::EPSILON);
         }
         cx.notify();
     }
 
     fn playback_toggle_volume(&mut self, _: &mut Window, cx: &mut Context<Self>) {
         let has_playable_target = match &self.preview.target {
-            PreviewTarget::Timeline(_) => self
+            PreviewTarget::Timeline => self
                 .timeline
                 .as_ref()
                 .is_some_and(|timeline| !timeline.data.clips.is_empty()),
@@ -277,6 +256,18 @@ impl PlaybackViewDelegate for Editor {
         if self.preview.volume_control_open {
             self.preview.volume_control_open = false;
             cx.notify();
+        }
+    }
+}
+
+impl Editor {
+    pub fn active_video(&self) -> Option<&VideoBackend> {
+        match &self.preview.target {
+            PreviewTarget::Timeline => Some(self.timeline.as_ref()?.video_backend.playback()),
+            PreviewTarget::VideoFile(_, video) => Some(video),
+            PreviewTarget::None | PreviewTarget::AudioFile(_, _) | PreviewTarget::ImageFile(_) => {
+                None
+            }
         }
     }
 }

--- a/rust/src/editor/preview.rs
+++ b/rust/src/editor/preview.rs
@@ -11,6 +11,22 @@ pub(super) enum PreviewTarget {
     ImageFile(PathBuf),
 }
 
+pub fn load_timeline_position_with_options(
+    preview: &mut PreviewState,
+    timeline: &mut TimelineRuntimeState,
+    position: TimelineTime,
+) {
+    let duration = timeline.data.content_duration();
+    let position = position.clamp(TimelineTime::ZERO, duration);
+    timeline.playhead = position;
+    preview.timeline_drag = None;
+
+    let video = preview.target.video_mut();
+    if let Some(video) = video {
+        let _ = video.seek(timeline.data.duration(position), true);
+    }
+}
+
 impl PreviewTarget {
     pub(super) fn is_timeline(&self) -> bool {
         matches!(self, Self::Timeline(_))
@@ -82,32 +98,6 @@ impl Editor {
         cx.notify();
     }
 
-    /// Deprecated because this couples playhead seeking to rebuilding the entire
-    /// GES preview pipeline instead of synchronizing timeline edits in place.
-    pub(super) fn load_timeline_position_with_options(
-        &mut self,
-        position: TimelineTime,
-        accurate: bool,
-    ) {
-        self.explorer.selected_file = None;
-        self.dismiss_context_menu();
-        let timeline = self
-            .timeline
-            .as_mut()
-            .expect("loading a timeline position requires an active timeline");
-        let video = self
-            .preview
-            .target
-            .video_mut()
-            .expect("loading a timeline position requires an active video preview");
-        let duration = timeline.data.content_duration();
-        let position = position.clamp(TimelineTime::ZERO, duration);
-        timeline.playhead = position;
-        self.preview.timeline_drag = None;
-
-        let _ = video.seek(timeline.data.duration(position), accurate);
-    }
-
     pub(super) fn toggle_playback(&mut self) {
         match &self.preview.target {
             PreviewTarget::None | PreviewTarget::ImageFile(_) => return,
@@ -144,7 +134,7 @@ impl Editor {
                     return;
                 };
                 video.set_paused(!is_paused);
-                self.load_timeline_position_with_options(start, true);
+                load_timeline_position_with_options(&mut self.preview, timeline, start);
             }
         }
     }
@@ -171,13 +161,13 @@ impl Editor {
     fn seek_preview_to_fraction(&mut self, fraction: f32) {
         let fraction = fraction.clamp(0.0, 1.0);
         if self.preview.target.is_timeline() {
-            let Some(timeline) = self.timeline.as_ref() else {
+            let Some(timeline) = self.timeline.as_mut() else {
                 return;
             };
             let duration = timeline.data.content_duration().frames();
             let position =
                 TimelineTime::from_frames((duration as f64 * fraction as f64).round() as i64);
-            self.load_timeline_position_with_options(position, true);
+            load_timeline_position_with_options(&mut self.preview, timeline, position);
             return;
         }
         if let PreviewTarget::VideoFile(_, video) = &mut self.preview.target {
@@ -231,9 +221,6 @@ impl PlaybackViewDelegate for Editor {
                 self.preview.last_scrub_seek = None;
                 self.preview.is_scrubbing = false;
                 self.seek_preview_to_fraction(fraction);
-                if self.preview.target.is_timeline() {
-                    self.save_timeline_playhead();
-                }
             }
             _ => return,
         }

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -55,21 +55,13 @@ pub fn preview_timeline_view(
     let has_media = !timeline.data.clips.is_empty();
 
     let duration = timeline.data.duration(timeline.data.content_duration());
-    let position = editor
-        .preview
-        .target
-        .video()
-        .map_or(Duration::ZERO, |v| v.position());
+    let position = timeline.video_backend.playback().position();
     let progress = if duration.is_zero() {
         0.0
     } else {
         (position.as_secs_f64() / duration.as_secs_f64()).clamp(0.0, 1.0) as f32
     };
-    let volume = editor
-        .preview
-        .target
-        .video()
-        .map_or(0.0, |video| video.volume().clamp(0.0, 1.0));
+    let volume = timeline.video_backend.playback().volume().clamp(0.0, 1.0);
     let muted = volume <= f64::EPSILON;
     let displayed_volume = if muted { 0.0 } else { volume } as f32;
     let volume_percent = (displayed_volume * 100.0).round() as u32;
@@ -158,21 +150,12 @@ pub fn preview_timeline_view(
                         }),
                     )
                 })
-                .child(if let Some(video_handle) = editor.preview.target.video() {
-                    video(video_handle)
+                .child(
+                    video(timeline.video_backend.playback())
                         .id("editor-timeline-video")
                         .size(px(width), px(surface_height))
-                        .into_any_element()
-                } else {
-                    div()
-                        .size_full()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .text_color(rgb(MUTED))
-                        .child("Choose a video from the project folder to begin")
-                        .into_any_element()
-                })
+                        .into_any_element(),
+                )
                 .when_some(snap_x, |this, guide| {
                     this.child(
                         div()
@@ -304,7 +287,7 @@ pub fn preview_timeline_view(
                                         } else {
                                             rgb(MUTED)
                                         })
-                                        .child(if editor.preview.target.video().map_or(false, |v| !v.paused()) { "Ⅱ" } else { "▶" })
+                                        .child(if !timeline.video_backend.playback().paused() { "Ⅱ" } else { "▶" })
                                         .on_click(
                                             cx.listener(Editor::toggle_timeline_preview_playback),
                                         ),
@@ -781,10 +764,12 @@ impl Editor {
             now.duration_since(last_update) >= TIMELINE_TRANSFORM_UPDATE_INTERVAL
         }) {
             drag.last_pipeline_update = Some(now);
-            if let Some(video) = self.preview.target.video_mut()
-                && let Err(error) =
-                    update_timeline_video_position(video, &timeline.data, drag.clip_id, false)
-            {
+            if let Err(error) = update_timeline_video_position(
+                &mut timeline.video_backend,
+                &timeline.data,
+                drag.clip_id,
+                false,
+            ) {
                 eprintln!("{error}");
             }
         }
@@ -799,11 +784,13 @@ impl Editor {
             return false;
         };
         if drag.changed {
-            if let Some(video) = self.preview.target.video_mut() {
-                let Some(timeline) = self.timeline.as_ref() else {
-                    return true;
-                };
-                match update_timeline_video_position(video, &timeline.data, drag.clip_id, true) {
+            if let Some(timeline) = self.timeline.as_mut() {
+                match update_timeline_video_position(
+                    &mut timeline.video_backend,
+                    &timeline.data,
+                    drag.clip_id,
+                    true,
+                ) {
                     Ok(()) => {}
                     Err(error) => eprintln!("{error}"),
                 }

--- a/rust/src/editor/preview_video.rs
+++ b/rust/src/editor/preview_video.rs
@@ -22,7 +22,7 @@ impl Editor {
             .justify_center()
             .overflow_hidden()
             .bg(rgb(0x000000))
-            .child(if let Some(video_handle) = self.preview.target.video() {
+            .child(if let Some(video_handle) = self.active_video() {
                 video(video_handle)
                     .id("editor-video-file-preview")
                     .size(px(width), px(surface_height))
@@ -39,19 +39,15 @@ impl Editor {
             })
             .into_any_element();
         let (position, duration, paused) = self
-            .preview
-            .target
-            .video()
+            .active_video()
             .map_or((Duration::ZERO, Duration::ZERO, true), |video| {
                 (video.position(), video.duration(), video.paused())
             });
 
-        let has_media = self.preview.target.video().is_some();
+        let has_media = self.active_video().is_some();
 
         let volume = self
-            .preview
-            .target
-            .video()
+            .active_video()
             .map_or(0.0, |video| video.volume().clamp(0.0, 1.0));
 
         playback_view(

--- a/rust/src/editor/settings.rs
+++ b/rust/src/editor/settings.rs
@@ -143,7 +143,7 @@ impl Editor {
         }
         let playhead = previous.rescale_nearest(timeline.playhead, frame_rate);
 
-        if let Some(video) = self.preview.target.video() {
+        if let Some(video) = self.active_video() {
             video.set_paused(true);
         }
         let Some(timeline) = self.timeline.as_mut() else {

--- a/rust/src/editor/settings.rs
+++ b/rust/src/editor/settings.rs
@@ -160,9 +160,9 @@ impl Editor {
         timeline.playhead = playhead.clamp(TimelineTime::ZERO, timeline.data.content_duration());
         let playhead = timeline.playhead;
         let has_clips = !timeline.data.clips.is_empty();
-        self.save_timeline_playhead();
+        timeline.save_timeline_playhead(&self.global_settings.project_root);
         if has_clips {
-            self.load_timeline_position_with_options(playhead, true);
+            load_timeline_position_with_options(&mut self.preview, timeline, playhead);
         }
         self.status = Some(format!(
             "Timeline frame rate changed to {}.",

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -46,7 +46,7 @@ pub(super) struct TimelineViewState {
 pub(super) struct TimelineRuntimeState {
     pub(super) path: PathBuf,
     pub(super) data: TimelineSerialization,
-    pub(super) ges_timeline: gstreamer_editing_services::Timeline,
+    pub(super) video_backend: TimelineVideoBackend,
     pub(super) playhead: TimelineTime,
     pub(super) h_scroll: ScrollHandle,
     pub(super) v_scroll: ScrollHandle,
@@ -406,7 +406,7 @@ impl TimelineRuntimeState {
         path: PathBuf,
         data: TimelineSerialization,
         ges_timeline: gstreamer_editing_services::Timeline,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let playhead = data
             .view
             .saved_playhead_frame
@@ -419,10 +419,11 @@ impl TimelineRuntimeState {
         let magnet_enabled = data.view.track_magnet_enabled;
         let selected_clip_id = data.clips.first().map(Clip::id);
         let selected_clip_ids = selected_clip_id.into_iter().collect();
-        Self {
+
+        Ok(Self {
             path,
             data,
-            ges_timeline,
+            video_backend: TimelineVideoBackend::new(ges_timeline)?,
             playhead,
             interaction: TimelineInteractionState {
                 active_tool: TimelineTool::Selection,
@@ -442,7 +443,7 @@ impl TimelineRuntimeState {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             preview_drop_asset: None,
-        }
+        })
     }
 
     pub(super) fn save_timeline_playhead(self: &mut TimelineRuntimeState, project_root: &Path) {

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -4,6 +4,7 @@ use super::model::{MediaAsset, MediaKind};
 use super::timeline_clip::Clip;
 use super::track::Track;
 use super::*;
+use anyhow::{Result, anyhow};
 use gpui::point;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -122,13 +123,16 @@ impl TimelineViewState {
 }
 
 impl TimelineSerialization {
-    pub fn load(path: &Path) -> anyhow::Result<Self> {
-        let contents = fs::read_to_string(path)
-            .map_err(|error| anyhow::anyhow!("could not read {}: {error}", path.display()))?;
-        let mut timeline = deserialize_timeline(&contents)
-            .map_err(|error| anyhow::anyhow!("could not parse {}: {error}", path.display()))?;
-        timeline.repair_and_prune_invalid_data();
-        Ok(timeline)
+    pub fn load(path: &Path) -> Result<Self> {
+        (|| -> Result<Self> {
+            let contents = fs::read_to_string(path)
+                .map_err(|error| anyhow!("could not read {}: {error}", path.display()))?;
+            let mut timeline = deserialize_timeline(&contents)
+                .map_err(|error| anyhow!("could not parse {}: {error}", path.display()))?;
+            timeline.repair_and_prune_invalid_data();
+            Ok(timeline)
+        })()
+        .context("TimelineSerialization::load failed")
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
@@ -425,7 +429,8 @@ impl TimelineRuntimeState {
         Ok(Self {
             path,
             data,
-            video_backend: TimelineVideoBackend::new(ges_timeline)?,
+            video_backend: TimelineVideoBackend::new(ges_timeline)
+                .context("TimelineVideoBackend::new failed")?,
             playhead,
             interaction: TimelineInteractionState {
                 active_tool: TimelineTool::Selection,

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -445,6 +445,11 @@ impl TimelineRuntimeState {
         }
     }
 
+    pub(super) fn save_timeline_playhead(self: &mut TimelineRuntimeState, project_root: &Path) {
+        self.capture_playhead(project_root);
+        self.save(project_root);
+    }
+
     pub(super) fn capture_playhead(&mut self, project_root: &Path) {
         edit_timeline(
             self,

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -30,6 +30,7 @@ pub(super) const FRAME_RATE_PRESETS: [(FrameRate, &str); 8] = [
 pub(super) struct TimelineSerialization {
     pub settings: TimelineSettings,
     pub assets: Vec<MediaAsset>,
+    #[serde(alias = "layers")]
     pub tracks: Vec<Track>,
     pub clips: Vec<Clip>,
     pub view: TimelineViewState,

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -1,3 +1,5 @@
+use crate::editor::timeline_document::deserialize_timeline;
+
 use super::model::{MediaAsset, MediaKind};
 use super::timeline_clip::Clip;
 use super::track::Track;
@@ -678,53 +680,6 @@ fn finite_nonnegative(value: f32) -> f32 {
     } else {
         0.0
     }
-}
-
-fn deserialize_timeline(contents: &str) -> anyhow::Result<TimelineSerialization> {
-    let mut value = serde_json::from_str::<serde_json::Value>(contents)?;
-    let frame_rate = value
-        .pointer("/settings/frame_rate")
-        .cloned()
-        .map(serde_json::from_value::<FrameRate>)
-        .transpose()?
-        .unwrap_or_default();
-    if let Some(clips) = value
-        .get_mut("clips")
-        .and_then(serde_json::Value::as_array_mut)
-    {
-        for clip in clips {
-            let Some(clip) = clip.as_object_mut() else {
-                continue;
-            };
-            if !clip.contains_key("text") && !clip.contains_key("properties") {
-                continue;
-            }
-            let Some(frames) = clip.get("length").and_then(serde_json::Value::as_i64) else {
-                continue;
-            };
-            clip.insert(
-                "length".to_string(),
-                serde_json::to_value(frame_rate.duration(TimelineTime::from_frames(frames)))?,
-            );
-        }
-    }
-    let mut timeline = serde_json::from_value::<TimelineSerialization>(value)?;
-    for clip in &mut timeline.clips {
-        let track_kind = timeline
-            .tracks
-            .iter()
-            .find(|track| track.id == clip.track_id())
-            .map(|track| track.kind);
-        let replacement = match (track_kind, &*clip) {
-            (Some(TrackKind::Audio), Clip::Video(data)) => Some(Clip::Audio(data.clone())),
-            (Some(TrackKind::Video), Clip::Audio(data)) => Some(Clip::Video(data.clone())),
-            _ => None,
-        };
-        if let Some(replacement) = replacement {
-            *clip = replacement;
-        }
-    }
-    Ok(timeline)
 }
 
 #[cfg(test)]

--- a/rust/src/editor/timeline.test.rs
+++ b/rust/src/editor/timeline.test.rs
@@ -736,20 +736,26 @@ fn text_properties_clip_is_rejected() {
 }
 
 #[test]
-fn frame_length_text_clip_deserializes_as_duration() {
-    let legacy = serde_json::json!({
-        "id": "01M0P9DJ506ZPJ4R4V7CH565X7",
-        "track_id": "01M0MCDDQWBN2HXFPJXY4BMQES",
-        "timeline_start": 12,
-        "length": 90,
-        "text": {
-            "text": "Frame title",
-            "future_text_field": true
+fn tagged_text_clip_deserializes_duration() {
+    let value = serde_json::json!({
+        "kind": "Text",
+        "data": {
+            "id": "01M0P9DJ506ZPJ4R4V7CH565X7",
+            "track_id": "01M0MCDDQWBN2HXFPJXY4BMQES",
+            "timeline_start": 12,
+            "length": {
+                "secs": 3,
+                "nanos": 0
+            },
+            "properties": {
+                "text": "Frame title",
+                "future_text_field": true
+            },
+            "future_clip_field": { "value": 1 }
         },
-        "future_clip_field": { "value": 1 }
     });
 
-    let clip = serde_json::from_value::<Clip>(legacy).unwrap();
+    let clip = serde_json::from_value::<Clip>(value).unwrap();
     assert_eq!(clip.text().unwrap().length, Duration::from_secs(3));
 }
 
@@ -763,11 +769,15 @@ fn timeline_load_migrates_frame_length_using_its_own_frame_rate() {
             "audio_sample_rate": 48000
         },
         "clips": [{
-            "id": "01M0P9DJ506ZPJ4R4V7CH565X7",
-            "track_id": "01M0MCDDQWBN2HXFPJXY4BMQES",
-            "timeline_start": 9090,
-            "length": 300,
-            "text": { "text": "Text", "future_field": true },
+            "kind": "Text",
+            "data": {
+                "id": "01M0P9DJ506ZPJ4R4V7CH565X7",
+                "track_id": "01M0MCDDQWBN2HXFPJXY4BMQES",
+                "timeline_start": 9090,
+                "length": 300,
+                "properties": { "text": "Text", "future_field": true },
+                "future_clip_field": true
+            },
             "future_clip_field": true
         }],
         "future_timeline_field": true

--- a/rust/src/editor/timeline.test.rs
+++ b/rust/src/editor/timeline.test.rs
@@ -774,7 +774,10 @@ fn timeline_load_migrates_frame_length_using_its_own_frame_rate() {
                 "id": "01M0P9DJ506ZPJ4R4V7CH565X7",
                 "track_id": "01M0MCDDQWBN2HXFPJXY4BMQES",
                 "timeline_start": 9090,
-                "length": 300,
+                "length": {
+                    "secs": 300,
+                    "nanos": 0,
+                },
                 "properties": { "text": "Text", "future_field": true },
                 "future_clip_field": true
             },
@@ -783,12 +786,13 @@ fn timeline_load_migrates_frame_length_using_its_own_frame_rate() {
         "future_timeline_field": true
     });
 
-    let timeline = deserialize_timeline(&json.to_string()).unwrap();
-
+    let timeline = deserialize_timeline(&json.to_string())
+        .inspect_err(|e| eprintln!("{e:#}"))
+        .unwrap();
     assert_eq!(
         timeline.clips[0].text().unwrap().length,
-        Duration::from_secs(5)
-    );
+        Duration::from_mins(5)
+    )
 }
 
 #[test]

--- a/rust/src/editor/timeline_clip.rs
+++ b/rust/src/editor/timeline_clip.rs
@@ -80,6 +80,7 @@ impl Default for TextClipProperties {
 // https://serde.rs/enum-representations.html#adjacently-tagged
 #[serde(tag = "kind", content = "data")]
 pub(super) enum Clip {
+    #[serde(alias = "Media")]
     Video(VideoClip),
     Audio(AudioClip),
     Text(TextClip),
@@ -89,7 +90,7 @@ pub(super) enum Clip {
 pub(super) struct MediaClipData {
     #[serde(deserialize_with = "deserialize_ulid")]
     pub id: Ulid,
-    #[serde(deserialize_with = "deserialize_ulid")]
+    #[serde(alias = "layer_id", deserialize_with = "deserialize_ulid")]
     pub track_id: Ulid,
     #[serde(default = "Ulid::nil", deserialize_with = "deserialize_ulid")]
     pub asset_id: Ulid,

--- a/rust/src/editor/timeline_clip.rs
+++ b/rust/src/editor/timeline_clip.rs
@@ -76,7 +76,8 @@ impl Default for TextClipProperties {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+// https://serde.rs/enum-representations.html#adjacently-tagged
 #[serde(tag = "kind", content = "data")]
 pub(super) enum Clip {
     Video(VideoClip),
@@ -237,84 +238,6 @@ impl Clip {
     }
 }
 
-impl<'de> Deserialize<'de> for Clip {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = serde_json::Value::deserialize(deserializer)?;
-        if let (Some(kind), Some(data)) = (
-            value.get("kind").and_then(serde_json::Value::as_str),
-            value.get("data").cloned(),
-        ) {
-            return match kind {
-                "Media" | "Video" => serde_json::from_value::<VideoClip>(data)
-                    .map(Self::Video)
-                    .map_err(serde::de::Error::custom),
-                "Audio" => serde_json::from_value::<AudioClip>(data)
-                    .map(Self::Audio)
-                    .map_err(serde::de::Error::custom),
-                "Text" => serde_json::from_value::<TextClip>(data)
-                    .map(Self::Text)
-                    .map_err(serde::de::Error::custom),
-                _ => Err(serde::de::Error::custom(format!(
-                    "unknown clip kind `{kind}`"
-                ))),
-            };
-        }
-        if value.get("text").is_some() {
-            if value
-                .get("length")
-                .is_some_and(serde_json::Value::is_number)
-            {
-                let clip = serde_json::from_value::<FrameLengthTextClip>(value)
-                    .map_err(serde::de::Error::custom)?;
-                return Ok(Self::Text(TextClip {
-                    id: clip.id,
-                    track_id: clip.track_id,
-                    timeline_start: clip.timeline_start,
-                    length: FrameRate::default().duration(clip.length),
-                    properties: clip.text,
-                }));
-            }
-            let mut value = value;
-            let object = value
-                .as_object_mut()
-                .ok_or_else(|| serde::de::Error::custom("clip must be a JSON object"))?;
-            let properties = object
-                .remove("text")
-                .ok_or_else(|| serde::de::Error::custom("text clip properties are missing"))?;
-            object.insert("properties".to_string(), properties);
-            return serde_json::from_value::<TextClip>(value)
-                .map(Self::Text)
-                .map_err(serde::de::Error::custom);
-        }
-        if value.get("properties").is_some() {
-            let mut value = value;
-            if value
-                .get("length")
-                .is_some_and(serde_json::Value::is_number)
-            {
-                let frames = value
-                    .get("length")
-                    .and_then(serde_json::Value::as_i64)
-                    .ok_or_else(|| serde::de::Error::custom("text clip length is invalid"))?;
-                value["length"] = serde_json::to_value(
-                    FrameRate::default().duration(TimelineTime::from_frames(frames)),
-                )
-                .map_err(serde::de::Error::custom)?;
-            }
-            return serde_json::from_value::<TextClip>(value)
-                .map(Self::Text)
-                .map_err(serde::de::Error::custom);
-        }
-
-        Err(serde::de::Error::custom(
-            "clip must use the tagged Video, Audio, or Text format",
-        ))
-    }
-}
-
 pub(super) fn text_clip_component(
     clip: TextClip,
     frame_rate: FrameRate,
@@ -351,15 +274,4 @@ pub(super) fn text_clip_component(
                 .text_ellipsis()
                 .child(clip.properties.text),
         )
-}
-
-#[derive(Deserialize)]
-struct FrameLengthTextClip {
-    #[serde(deserialize_with = "deserialize_ulid")]
-    id: Ulid,
-    #[serde(deserialize_with = "deserialize_ulid")]
-    track_id: Ulid,
-    timeline_start: TimelineTime,
-    length: TimelineTime,
-    text: TextClipProperties,
 }

--- a/rust/src/editor/timeline_document.rs
+++ b/rust/src/editor/timeline_document.rs
@@ -1,7 +1,7 @@
 use crate::editor::{Clip, FrameRate, TimelineTime, TrackKind};
 
 use super::timeline::TimelineSerialization;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -161,12 +161,14 @@ fn timeline_file_names(directory: &Path) -> anyhow::Result<Vec<String>> {
 }
 
 pub fn deserialize_timeline(contents: &str) -> Result<TimelineSerialization> {
-    let mut value = serde_json::from_str::<serde_json::Value>(contents)?;
+    let mut value = serde_json::from_str::<serde_json::Value>(contents)
+        .context("could not parse timeline JSON")?;
     let frame_rate = value
         .pointer("/settings/frame_rate")
         .cloned()
         .map(serde_json::from_value::<FrameRate>)
-        .transpose()?
+        .transpose()
+        .context("could not deserialize timeline frame rate")?
         .unwrap_or_default();
     if let Some(clips) = value
         .get_mut("clips")
@@ -184,11 +186,13 @@ pub fn deserialize_timeline(contents: &str) -> Result<TimelineSerialization> {
             };
             clip.insert(
                 "length".to_string(),
-                serde_json::to_value(frame_rate.duration(TimelineTime::from_frames(frames)))?,
+                serde_json::to_value(frame_rate.duration(TimelineTime::from_frames(frames)))
+                    .context("could not serialize migrated text clip duration")?,
             );
         }
     }
-    let mut timeline = serde_json::from_value::<TimelineSerialization>(value)?;
+    let mut timeline = serde_json::from_value::<TimelineSerialization>(value)
+        .context("could not deserialize timeline data")?;
     for clip in &mut timeline.clips {
         let track_kind = timeline
             .tracks

--- a/rust/src/editor/timeline_document.rs
+++ b/rust/src/editor/timeline_document.rs
@@ -1,4 +1,7 @@
+use crate::editor::{Clip, FrameRate, TimelineTime, TrackKind};
+
 use super::timeline::TimelineSerialization;
+use anyhow::Result;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -155,6 +158,53 @@ fn timeline_file_names(directory: &Path) -> anyhow::Result<Vec<String>> {
                 .flatten()
         })
         .collect())
+}
+
+pub fn deserialize_timeline(contents: &str) -> Result<TimelineSerialization> {
+    let mut value = serde_json::from_str::<serde_json::Value>(contents)?;
+    let frame_rate = value
+        .pointer("/settings/frame_rate")
+        .cloned()
+        .map(serde_json::from_value::<FrameRate>)
+        .transpose()?
+        .unwrap_or_default();
+    if let Some(clips) = value
+        .get_mut("clips")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for clip in clips {
+            let Some(clip) = clip.as_object_mut() else {
+                continue;
+            };
+            if !clip.contains_key("text") && !clip.contains_key("properties") {
+                continue;
+            }
+            let Some(frames) = clip.get("length").and_then(serde_json::Value::as_i64) else {
+                continue;
+            };
+            clip.insert(
+                "length".to_string(),
+                serde_json::to_value(frame_rate.duration(TimelineTime::from_frames(frames)))?,
+            );
+        }
+    }
+    let mut timeline = serde_json::from_value::<TimelineSerialization>(value)?;
+    for clip in &mut timeline.clips {
+        let track_kind = timeline
+            .tracks
+            .iter()
+            .find(|track| track.id == clip.track_id())
+            .map(|track| track.kind);
+        let replacement = match (track_kind, &*clip) {
+            (Some(TrackKind::Audio), Clip::Video(data)) => Some(Clip::Audio(data.clone())),
+            (Some(TrackKind::Video), Clip::Audio(data)) => Some(Clip::Video(data.clone())),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            *clip = replacement;
+        }
+    }
+    Ok(timeline)
 }
 
 #[cfg(test)]

--- a/rust/src/editor/timeline_interactions.rs
+++ b/rust/src/editor/timeline_interactions.rs
@@ -472,7 +472,7 @@ impl Editor {
         {
             return;
         }
-        if let Some(video) = self.preview.target.video() {
+        if let Some(video) = self.active_video() {
             video.set_paused(true);
         }
         let timeline = self.timeline.as_mut().expect("timeline was checked above");
@@ -724,13 +724,13 @@ impl Editor {
     }
 
     pub(super) fn begin_playhead_scrub(&mut self, event: &MouseDownEvent) {
+        if let Some(video) = self.active_video() {
+            video.set_paused(true);
+        }
         let Some(timeline) = self.timeline.as_mut() else {
             return;
         };
         timeline.interaction.scrubbing_playhead = true;
-        if let Some(video) = self.preview.target.video() {
-            video.set_paused(true);
-        }
         let position = timeline.timeline_position_from_x(event.position.x.into());
         timeline.interaction.last_scrub_seek = Some(Instant::now());
         load_timeline_position_with_options(&mut self.preview, timeline, position);

--- a/rust/src/editor/timeline_interactions.rs
+++ b/rust/src/editor/timeline_interactions.rs
@@ -637,10 +637,8 @@ impl Editor {
                 },
             )
             .expect("clip move placements were validated during the drag");
-            let playhead = timeline.playhead;
-            timeline.save(&self.global_settings.project_root);
 
-            self.load_timeline_position_with_options(playhead, true);
+            timeline.save(&self.global_settings.project_root);
         }
         cx.notify();
     }
@@ -735,7 +733,7 @@ impl Editor {
         }
         let position = timeline.timeline_position_from_x(event.position.x.into());
         timeline.interaction.last_scrub_seek = Some(Instant::now());
-        self.load_timeline_position_with_options(position, false);
+        load_timeline_position_with_options(&mut self.preview, timeline, position);
     }
 
     pub(super) fn update_playhead_scrub(
@@ -763,7 +761,7 @@ impl Editor {
             .is_none_or(|last_seek| now.duration_since(last_seek) >= SCRUB_SEEK_INTERVAL);
         if should_seek {
             timeline.interaction.last_scrub_seek = Some(now);
-            self.load_timeline_position_with_options(position, false);
+            load_timeline_position_with_options(&mut self.preview, timeline, position);
         }
         cx.notify();
     }
@@ -783,13 +781,13 @@ impl Editor {
         timeline.interaction.scrubbing_playhead = false;
         timeline.interaction.last_scrub_seek = None;
         let position = timeline.timeline_position_from_x(event.position.x.into());
-        self.load_timeline_position_with_options(position, true);
-        self.save_timeline_playhead();
+        load_timeline_position_with_options(&mut self.preview, timeline, position);
+        timeline.save_timeline_playhead(&self.global_settings.project_root);
         cx.notify();
     }
 
     pub(super) fn step_playhead(&mut self, frames: i64) {
-        let Some(timeline) = self.timeline.as_ref() else {
+        let Some(timeline) = self.timeline.as_mut() else {
             return;
         };
         if timeline.data.clips.is_empty() {
@@ -798,8 +796,8 @@ impl Editor {
         let target = (timeline.playhead + TimelineTime::from_frames(frames))
             .clamp(TimelineTime::ZERO, timeline.data.content_duration());
         if target != timeline.playhead || !self.preview.target.is_timeline() {
-            self.load_timeline_position_with_options(target, true);
-            self.save_timeline_playhead();
+            load_timeline_position_with_options(&mut self.preview, timeline, target);
+            timeline.save_timeline_playhead(&self.global_settings.project_root);
         }
     }
 }

--- a/rust/src/editor/timeline_ui.rs
+++ b/rust/src/editor/timeline_ui.rs
@@ -458,7 +458,7 @@ impl Editor {
                     .child(
                         timeline_icon_button(
                             "timeline-play",
-                            if self.preview.target.video().map_or(false, |v| !v.paused()) {
+                            if self.active_video().is_some_and(|video| !video.paused()) {
                                 "Ⅱ"
                             } else {
                                 "▶"

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -3,6 +3,7 @@ use super::{
     timeline::TimelineSerialization,
 };
 use crate::video::VideoBackend;
+use anyhow::Result;
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -11,16 +12,35 @@ use gstreamer_editing_services as ges;
 
 use ulid::Ulid;
 
-pub(super) fn create_timeline_video(timeline: &ges::Timeline) -> anyhow::Result<VideoBackend> {
-    initialize_gstreamer()?;
-    let (audio_sink, volume_control) = preview_audio_sink()?;
-    let (pipeline, sink) = create_timeline_pipeline_v2(timeline, &audio_sink)?;
-    VideoBackend::from_pipeline(pipeline, sink, volume_control)
-        .map_err(|error| anyhow::anyhow!("could not initialize timeline video: {error}"))
+pub struct TimelineVideoBackend {
+    ges_timeline: ges::Timeline,
+    playback: VideoBackend,
+}
+
+impl TimelineVideoBackend {
+    pub fn new(ges_timeline: ges::Timeline) -> Result<TimelineVideoBackend> {
+        let playback = create_timeline_playback(&ges_timeline)?;
+        Ok(Self {
+            ges_timeline,
+            playback,
+        })
+    }
+
+    pub fn ges_timeline(&self) -> &ges::Timeline {
+        &self.ges_timeline
+    }
+
+    pub fn playback(&self) -> &VideoBackend {
+        &self.playback
+    }
+
+    pub fn playback_mut(&mut self) -> &mut VideoBackend {
+        &mut self.playback
+    }
 }
 
 pub(super) fn update_timeline_video_position(
-    video: &mut VideoBackend,
+    video: &mut TimelineVideoBackend,
     timeline_data: &TimelineSerialization,
     clip_id: Ulid,
     refresh_frame: bool,
@@ -34,13 +54,7 @@ pub(super) fn update_timeline_video_position(
     let asset = timeline_data
         .asset(clip.asset_id)
         .ok_or_else(|| anyhow::anyhow!("Clip {clip_id} has no source media."))?;
-    let pipeline = video
-        .pipeline()
-        .downcast::<ges::Pipeline>()
-        .map_err(|_| anyhow::anyhow!("timeline preview pipeline had an unexpected type"))?;
-    let timeline = pipeline
-        .timeline()
-        .ok_or_else(|| anyhow::anyhow!("timeline preview pipeline has no timeline"))?;
+    let timeline = &video.ges_timeline;
     let clip_name = format!("opencut-clip-{clip_id}");
     let rendered_clip = timeline
         .layers()
@@ -84,9 +98,9 @@ pub(super) fn update_timeline_video_position(
     if !timeline.commit_sync() {
         anyhow::bail!("GStreamer could not commit the preview position.");
     }
-    video
-        .seek(video.position(), true)
-        .map_err(anyhow::Error::msg)
+    let playback = &mut video.playback;
+    let position = playback.position();
+    playback.seek(position, true).map_err(anyhow::Error::msg)
 }
 
 pub fn create_timeline_pipeline_v2(
@@ -115,6 +129,14 @@ pub fn create_timeline_pipeline_v2(
         .map_err(|error| anyhow::anyhow!("could not enable GStreamer preview mode: {error}"))?;
 
     Ok((pipeline.upcast(), sink))
+}
+
+fn create_timeline_playback(timeline: &ges::Timeline) -> anyhow::Result<VideoBackend> {
+    initialize_gstreamer()?;
+    let (audio_sink, volume_control) = preview_audio_sink()?;
+    let (pipeline, sink) = create_timeline_pipeline_v2(timeline, &audio_sink)?;
+    VideoBackend::from_pipeline(pipeline, sink, volume_control)
+        .map_err(|error| anyhow::anyhow!("could not initialize timeline video: {error}"))
 }
 
 fn initialize_gstreamer() -> anyhow::Result<()> {

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -100,7 +100,7 @@ pub(super) fn update_timeline_video_position(
     }
     let playback = &mut video.playback;
     let position = playback.position();
-    playback.seek(position, true).map_err(anyhow::Error::msg)
+    playback.seek(position).map_err(anyhow::Error::msg)
 }
 
 pub fn create_timeline_pipeline_v2(

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -3,7 +3,7 @@ use super::{
     timeline::TimelineSerialization,
 };
 use crate::video::VideoBackend;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -19,7 +19,8 @@ pub struct TimelineVideoBackend {
 
 impl TimelineVideoBackend {
     pub fn new(ges_timeline: ges::Timeline) -> Result<TimelineVideoBackend> {
-        let playback = create_timeline_playback(&ges_timeline)?;
+        let playback =
+            create_timeline_playback(&ges_timeline).context("create_timeline_playback failed")?;
         Ok(Self {
             ges_timeline,
             playback,

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -132,12 +132,14 @@ pub fn create_timeline_pipeline_v2(
     Ok((pipeline.upcast(), sink))
 }
 
-fn create_timeline_playback(timeline: &ges::Timeline) -> anyhow::Result<VideoBackend> {
-    initialize_gstreamer()?;
-    let (audio_sink, volume_control) = preview_audio_sink()?;
-    let (pipeline, sink) = create_timeline_pipeline_v2(timeline, &audio_sink)?;
-    VideoBackend::from_pipeline(pipeline, sink, volume_control)
-        .map_err(|error| anyhow::anyhow!("could not initialize timeline video: {error}"))
+fn create_timeline_playback(timeline: &ges::Timeline) -> Result<VideoBackend> {
+    (|| -> Result<VideoBackend> {
+        initialize_gstreamer()?;
+        let (audio_sink, volume_control) = preview_audio_sink()?;
+        let (pipeline, sink) = create_timeline_pipeline_v2(timeline, &audio_sink)?;
+        VideoBackend::from_pipeline(pipeline, sink, volume_control)
+    })()
+    .context("create_timeline_playback failed")
 }
 
 fn initialize_gstreamer() -> anyhow::Result<()> {

--- a/rust/src/player/mod.rs
+++ b/rust/src/player/mod.rs
@@ -236,7 +236,7 @@ impl Player {
         .min(duration);
 
         self.pending_seek_started = Some(Instant::now());
-        let _ = video.seek(target, true);
+        let _ = video.seek(target);
     }
 
     fn seek_to_fraction(&mut self, fraction: f64) {
@@ -244,7 +244,7 @@ impl Player {
             return;
         };
         let target = video.duration().mul_f64(fraction.clamp(0.0, 1.0));
-        let _ = video.seek(target, true);
+        let _ = video.seek(target);
     }
 
     fn set_history_width_from_x(&mut self, x: f32, window: &Window) {

--- a/rust/src/player/mod.rs
+++ b/rust/src/player/mod.rs
@@ -9,7 +9,7 @@ use std::{path::PathBuf, time::Duration, time::Instant};
 use url::Url;
 
 use crate::playback_view::{DragPhase, PlaybackViewDelegate};
-use crate::video::VideoBackend;
+use crate::video::FileVideoBackend;
 
 mod history;
 mod inspector;
@@ -62,7 +62,7 @@ pub(crate) fn bind_keys(cx: &mut App) {
 }
 
 pub(crate) struct Player {
-    video: Option<VideoBackend>,
+    video: Option<FileVideoBackend>,
     history: HistoryData,
     current_media_path: Option<PathBuf>,
     title: String,
@@ -182,7 +182,7 @@ impl Player {
             return;
         };
 
-        match VideoBackend::open(&url) {
+        match FileVideoBackend::open(&url) {
             Ok(video) => {
                 self.video = Some(video);
                 self.history.record(&path, title.clone());

--- a/rust/src/player/view.rs
+++ b/rust/src/player/view.rs
@@ -82,8 +82,8 @@ impl Render for Player {
         let video_height = (viewport_height - HEADER_HEIGHT - CONTROL_HEIGHT).max(140.0);
 
         let has_video = self.video.is_some();
-        let is_paused = self.video.as_ref().is_none_or(VideoBackend::paused);
-        let is_muted = self.video.as_ref().is_some_and(VideoBackend::muted);
+        let is_paused = self.video.as_ref().is_none_or(|video| video.paused());
+        let is_muted = self.video.as_ref().is_some_and(|video| video.muted());
         let volume = self
             .video
             .as_ref()
@@ -92,11 +92,11 @@ impl Render for Player {
         let duration = self
             .video
             .as_ref()
-            .map_or(Duration::ZERO, VideoBackend::duration);
+            .map_or(Duration::ZERO, |video| video.duration());
         let position = self
             .video
             .as_ref()
-            .map_or(Duration::ZERO, VideoBackend::position);
+            .map_or(Duration::ZERO, |video| video.position());
 
         let display_title = self.display_title();
 

--- a/rust/src/video/mod.rs
+++ b/rust/src/video/mod.rs
@@ -2,4 +2,4 @@ mod video_element;
 pub(crate) use video_element::video;
 
 mod video_backend;
-pub(crate) use video_backend::VideoBackend;
+pub(crate) use video_backend::{FileVideoBackend, VideoBackend};

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use anyhow::{Context as _, Error, Result, bail};
+use anyhow::{Context as _, Error, Result, anyhow, bail};
 use gst::prelude::*;
 
 use gst_audio::prelude::StreamVolumeExt as _;
@@ -228,15 +228,15 @@ pub(crate) struct FileVideoBackend {
 }
 
 impl FileVideoBackend {
-    pub(crate) fn open(uri: &Url) -> Result<Self, String> {
-        gst::init().map_err(|error| format!("could not initialize GStreamer: {error}"))?;
+    pub(crate) fn open(uri: &Url) -> Result<Self> {
+        gst::init().context("could not initialize GStreamer")?;
         let caps = gst_video::VideoCapsBuilder::new()
             .format(gst_video::VideoFormat::Nv12)
             .pixel_aspect_ratio(gst::Fraction::new(1, 1))
             .build();
         let converter = gst::ElementFactory::make("videoconvert")
             .build()
-            .map_err(|error| format!("could not create video converter: {error}"))?;
+            .context("could not create video converter")?;
         let sink = gst_app::AppSink::builder()
             .name("opencut_player_video")
             .drop(true)
@@ -247,40 +247,36 @@ impl FileVideoBackend {
         let video_sink = gst::Bin::new();
         video_sink
             .add(&converter)
-            .map_err(|error| format!("could not add video converter: {error}"))?;
-        video_sink
-            .add(&sink)
-            .map_err(|error| format!("could not add video sink: {error}"))?;
-        converter
-            .link(&sink)
-            .map_err(|error| format!("could not link video sink: {error}"))?;
+            .context("could not add video converter")?;
+        video_sink.add(&sink).context("could not add video sink")?;
+        converter.link(&sink).context("could not link video sink")?;
         let converter_sink_pad = converter
             .static_pad("sink")
-            .ok_or_else(|| "video converter has no sink pad".to_string())?;
+            .ok_or_else(|| anyhow!("video converter has no sink pad"))?;
         let ghost_pad = gst::GhostPad::builder_with_target(&converter_sink_pad)
-            .map_err(|error| format!("could not create video sink pad: {error}"))?
+            .context("could not create video sink pad")?
             .name("sink")
             .build();
         ghost_pad
             .set_active(true)
-            .map_err(|error| format!("could not activate video sink pad: {error}"))?;
+            .context("could not activate video sink pad")?;
         video_sink
             .add_pad(&ghost_pad)
-            .map_err(|error| format!("could not expose video sink pad: {error}"))?;
+            .context("could not expose video sink pad")?;
         let playbin = gst::ElementFactory::make("playbin")
             .property("uri", uri.as_str())
             .property("video-sink", &video_sink)
             .build()
-            .map_err(|error| format!("could not create video pipeline: {error}"))?;
+            .context("could not create video pipeline")?;
         let pipeline = playbin
             .downcast::<gst::Pipeline>()
-            .map_err(|_| "video pipeline had an unexpected type".to_string())?;
+            .map_err(|_| anyhow!("video pipeline had an unexpected type"))?;
 
         let volume_control = pipeline
             .clone()
             .upcast::<gst::Element>()
             .dynamic_cast::<gst_audio::StreamVolume>()
-            .map_err(|_| "video pipeline does not support stream volume".to_string())?;
+            .map_err(|_| anyhow!("video pipeline does not support stream volume"))?;
         let video = VideoBackend::from_pipeline(pipeline, sink, volume_control)?;
         video.set_paused(false);
         Ok(Self { playback: video })

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -163,7 +163,7 @@ impl VideoBackend {
 
     /// The negotiated frame rate, or `None` for variable-frame-rate sources where
     /// GStreamer reports `0/1`.
-    pub(crate) fn framerate(&self) -> Option<f64> {
+    pub fn framerate(&self) -> Option<f64> {
         let caps = self.cap().ok()?;
         let info = match gst_video::VideoInfo::from_caps(&caps) {
             Ok(info) => info,

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+use anyhow::{Context as _, Error, Result, bail};
 use gst::prelude::*;
 
 use gst_audio::prelude::StreamVolumeExt as _;
@@ -37,8 +38,8 @@ impl VideoBackend {
         pipeline: gst::Pipeline,
         sink: gst_app::AppSink,
         volume_control: gst_audio::StreamVolume,
-    ) -> Result<Self, String> {
-        gst::init().map_err(|error| format!("could not initialize GStreamer: {error}"))?;
+    ) -> Result<Self> {
+        gst::init().context("could not initialize GStreamer")?;
         let current_frame = Arc::new(Mutex::new(None));
         sink.set_callbacks(
             gst_app::AppSinkCallbacks::builder()
@@ -62,10 +63,10 @@ impl VideoBackend {
         );
         pipeline
             .set_state(gst::State::Paused)
-            .map_err(|error| format!("could not prepare video: {error}"))?;
+            .context("could not prepare video")?;
         if let Err(error) = pipeline.state(gst::ClockTime::from_seconds(5)).0 {
             let _ = pipeline.set_state(gst::State::Null);
-            return Err(format!("video did not finish preparing: {error}"));
+            return Err(Error::new(error).context("video did not finish preparing"));
         }
         let Some(caps) = sink
             .static_pad("sink")
@@ -73,13 +74,13 @@ impl VideoBackend {
             .current_caps()
         else {
             let _ = pipeline.set_state(gst::State::Null);
-            return Err("video caps were not negotiated".to_string());
+            bail!("video caps were not negotiated");
         };
         let info = match gst_video::VideoInfo::from_caps(&caps) {
             Ok(info) => info,
             Err(error) => {
                 let _ = pipeline.set_state(gst::State::Null);
-                return Err(format!("video caps did not describe raw video: {error}"));
+                return Err(Error::new(error).context("video caps did not describe raw video"));
             }
         };
         let frame_size = (info.width(), info.height());

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -1,3 +1,4 @@
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use gst::prelude::*;
@@ -32,65 +33,6 @@ impl Drop for VideoBackend {
 }
 
 impl VideoBackend {
-    // pub fn from_file(path: Path) -> Result<Self, String> {}
-    pub(crate) fn open(uri: &Url) -> Result<Self, String> {
-        gst::init().map_err(|error| format!("could not initialize GStreamer: {error}"))?;
-        let caps = gst_video::VideoCapsBuilder::new()
-            .format(gst_video::VideoFormat::Nv12)
-            .pixel_aspect_ratio(gst::Fraction::new(1, 1))
-            .build();
-        let converter = gst::ElementFactory::make("videoconvert")
-            .build()
-            .map_err(|error| format!("could not create video converter: {error}"))?;
-        let sink = gst_app::AppSink::builder()
-            .name("opencut_player_video")
-            .drop(true)
-            .max_buffers(3)
-            .enable_last_sample(false)
-            .caps(&caps)
-            .build();
-        let video_sink = gst::Bin::new();
-        video_sink
-            .add(&converter)
-            .map_err(|error| format!("could not add video converter: {error}"))?;
-        video_sink
-            .add(&sink)
-            .map_err(|error| format!("could not add video sink: {error}"))?;
-        converter
-            .link(&sink)
-            .map_err(|error| format!("could not link video sink: {error}"))?;
-        let converter_sink_pad = converter
-            .static_pad("sink")
-            .ok_or_else(|| "video converter has no sink pad".to_string())?;
-        let ghost_pad = gst::GhostPad::builder_with_target(&converter_sink_pad)
-            .map_err(|error| format!("could not create video sink pad: {error}"))?
-            .name("sink")
-            .build();
-        ghost_pad
-            .set_active(true)
-            .map_err(|error| format!("could not activate video sink pad: {error}"))?;
-        video_sink
-            .add_pad(&ghost_pad)
-            .map_err(|error| format!("could not expose video sink pad: {error}"))?;
-        let playbin = gst::ElementFactory::make("playbin")
-            .property("uri", uri.as_str())
-            .property("video-sink", &video_sink)
-            .build()
-            .map_err(|error| format!("could not create video pipeline: {error}"))?;
-        let pipeline = playbin
-            .downcast::<gst::Pipeline>()
-            .map_err(|_| "video pipeline had an unexpected type".to_string())?;
-
-        let volume_control = pipeline
-            .clone()
-            .upcast::<gst::Element>()
-            .dynamic_cast::<gst_audio::StreamVolume>()
-            .map_err(|_| "video pipeline does not support stream volume".to_string())?;
-        let video = Self::from_pipeline(pipeline, sink, volume_control)?;
-        video.set_paused(false);
-        Ok(video)
-    }
-
     pub(crate) fn from_pipeline(
         pipeline: gst::Pipeline,
         sink: gst_app::AppSink,
@@ -140,21 +82,33 @@ impl VideoBackend {
                 return Err(format!("video caps did not describe raw video: {error}"));
             }
         };
-        let _frame_size = (info.width(), info.height());
+        let frame_size = (info.width(), info.height());
 
         // GStreamer negotiates `framerate=0/1` for variable-frame-rate sources such as
         // screen recordings. That is a valid "unknown rate" marker, not a broken file, so
         // it must not fail the load — the container's nominal rate is still available from
         // the probed asset when a caller needs one.
 
-        Ok(VideoBackend {
+        Ok(Self {
             current_frame,
             pipeline,
             sink,
             volume_control,
             cached_position: Duration::ZERO,
-            _frame_size,
+            _frame_size: frame_size,
         })
+    }
+
+    fn cap(&self) -> Result<gst::Caps, String> {
+        let pad = self
+            .sink
+            .static_pad("sink")
+            .expect("AppSink must have a static sink pad");
+
+        let Some(caps) = pad.current_caps() else {
+            return Err("video caps were not negotiated".to_string());
+        };
+        Ok(caps)
     }
 
     pub(crate) fn frame_size(&self) -> (u32, u32) {
@@ -258,20 +212,84 @@ impl VideoBackend {
     pub fn get_current_frame(&self) -> Option<gst::Sample> {
         self.current_frame.lock().clone()
     }
+}
 
-    //////////////////////
-    // Private  Methods //
-    //////////////////////
-    fn cap(&self) -> Result<gst::Caps, String> {
-        let pad = self
-            .sink
+#[derive(Debug)]
+pub(crate) struct FileVideoBackend {
+    playback: VideoBackend,
+}
+
+impl FileVideoBackend {
+    pub(crate) fn open(uri: &Url) -> Result<Self, String> {
+        gst::init().map_err(|error| format!("could not initialize GStreamer: {error}"))?;
+        let caps = gst_video::VideoCapsBuilder::new()
+            .format(gst_video::VideoFormat::Nv12)
+            .pixel_aspect_ratio(gst::Fraction::new(1, 1))
+            .build();
+        let converter = gst::ElementFactory::make("videoconvert")
+            .build()
+            .map_err(|error| format!("could not create video converter: {error}"))?;
+        let sink = gst_app::AppSink::builder()
+            .name("opencut_player_video")
+            .drop(true)
+            .max_buffers(3)
+            .enable_last_sample(false)
+            .caps(&caps)
+            .build();
+        let video_sink = gst::Bin::new();
+        video_sink
+            .add(&converter)
+            .map_err(|error| format!("could not add video converter: {error}"))?;
+        video_sink
+            .add(&sink)
+            .map_err(|error| format!("could not add video sink: {error}"))?;
+        converter
+            .link(&sink)
+            .map_err(|error| format!("could not link video sink: {error}"))?;
+        let converter_sink_pad = converter
             .static_pad("sink")
-            .expect("AppSink must have a static sink pad");
+            .ok_or_else(|| "video converter has no sink pad".to_string())?;
+        let ghost_pad = gst::GhostPad::builder_with_target(&converter_sink_pad)
+            .map_err(|error| format!("could not create video sink pad: {error}"))?
+            .name("sink")
+            .build();
+        ghost_pad
+            .set_active(true)
+            .map_err(|error| format!("could not activate video sink pad: {error}"))?;
+        video_sink
+            .add_pad(&ghost_pad)
+            .map_err(|error| format!("could not expose video sink pad: {error}"))?;
+        let playbin = gst::ElementFactory::make("playbin")
+            .property("uri", uri.as_str())
+            .property("video-sink", &video_sink)
+            .build()
+            .map_err(|error| format!("could not create video pipeline: {error}"))?;
+        let pipeline = playbin
+            .downcast::<gst::Pipeline>()
+            .map_err(|_| "video pipeline had an unexpected type".to_string())?;
 
-        let Some(caps) = pad.current_caps() else {
-            return Err("video caps were not negotiated".to_string());
-        };
-        return Ok(caps);
+        let volume_control = pipeline
+            .clone()
+            .upcast::<gst::Element>()
+            .dynamic_cast::<gst_audio::StreamVolume>()
+            .map_err(|_| "video pipeline does not support stream volume".to_string())?;
+        let video = VideoBackend::from_pipeline(pipeline, sink, volume_control)?;
+        video.set_paused(false);
+        Ok(Self { playback: video })
+    }
+}
+
+impl Deref for FileVideoBackend {
+    type Target = VideoBackend;
+
+    fn deref(&self) -> &Self::Target {
+        &self.playback
+    }
+}
+
+impl DerefMut for FileVideoBackend {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.playback
     }
 }
 

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -162,21 +162,28 @@ impl VideoBackend {
         }
     }
 
-    pub(crate) fn seek(&mut self, position: Duration, accurate: bool) -> Result<(), String> {
+    pub(crate) fn seek(&mut self, position: Duration) -> Result<(), String> {
         let mut flags = gst::SeekFlags::FLUSH;
-        if accurate {
-            flags |= gst::SeekFlags::ACCURATE;
-        } else {
-            flags |= gst::SeekFlags::KEY_UNIT | gst::SeekFlags::SNAP_AFTER;
-        }
+        flags |= gst::SeekFlags::ACCURATE;
+
+        let stop = self.duration();
+        let final_frame_start = self
+            .framerate()
+            .map(|frame_rate| {
+                let frame_duration = Duration::from_secs_f64(1.0 / frame_rate);
+                stop.saturating_sub(frame_duration)
+            })
+            .unwrap_or_else(|| stop.saturating_sub(Duration::from_nanos(1)));
+        let position = position.min(final_frame_start);
+
         self.pipeline
             .seek(
                 1.0,
                 flags,
                 gst::SeekType::Set,
                 gst::ClockTime::from_nseconds(position.as_nanos() as u64),
-                gst::SeekType::None,
-                gst::ClockTime::NONE,
+                gst::SeekType::Set,
+                gst::ClockTime::from_nseconds(stop.as_nanos() as u64),
             )
             .map_err(|error| format!("could not seek video: {error}"))?;
         self.cached_position = position;

--- a/rust/src/video/video_backend.test.rs
+++ b/rust/src/video/video_backend.test.rs
@@ -55,7 +55,7 @@ fn measures_seek_to_half_of_a_video() {
 
     let started_at = Instant::now();
     video
-        .seek(target, false)
+        .seek(target)
         .expect("could not seek test video to its midpoint");
     let elapsed = started_at.elapsed();
 

--- a/rust/src/video/video_backend.test.rs
+++ b/rust/src/video/video_backend.test.rs
@@ -41,7 +41,7 @@ fn measures_seek_to_half_of_a_video() {
     let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("data/tests/long video.mp4");
     let uri = Url::from_file_path(&source)
         .unwrap_or_else(|_| panic!("could not convert {} to a file URL", source.display()));
-    let mut video = VideoBackend::open(&uri).expect("could not open test video");
+    let mut video = FileVideoBackend::open(&uri).expect("could not open test video");
     video.set_paused(true);
     video
         .pipeline()
@@ -59,5 +59,5 @@ fn measures_seek_to_half_of_a_video() {
         .expect("could not seek test video to its midpoint");
     let elapsed = started_at.elapsed();
 
-    eprintln!("VideoBackend::seek to 50% ({target:?} of {duration:?}) took {elapsed:?}");
+    eprintln!("FileVideoBackend::seek to 50% ({target:?} of {duration:?}) took {elapsed:?}");
 }


### PR DESCRIPTION
## Summary

- Introduce `TimelineVideoBackend` to own the GES timeline and its persistent playback backend.
- Separate file playback into `FileVideoBackend`.
- Reuse timeline playback when switching preview targets instead of reconstructing the pipeline.
- Apply add, remove, move, update, and split operations directly to GES and commit them explicitly.
- Add an atomic `SplitClips` edit action.
- Clamp seeks to the final decodable frame to avoid invalid GStreamer seek ranges.
- Restore compatibility with legacy `layers`, `Media`, and `layer_id` timeline fields.
- Propagate structured `anyhow` error chains and handle timeline-open failures without panicking.

## Motivation

Timeline playback was tied to `PreviewTarget`, so switching to a file preview dropped the timeline video pipeline and required it to be reconstructed later. Timeline edits also caused unnecessary seeks or pipeline rebuilds, and end-of-timeline seeks could produce invalid GStreamer segments.

