### PR TITLE
fix(editor): initialize empty timelines without waiting for video caps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@
 - When a function call returns an error, propagate it through intermediate
   functions instead of logging it there. Log the error only at the highest-level
   application, event, or task boundary.
+- When refactoring or adding error-handling code, always include `file!()` and
+  `line!()` information in every newly added error context.
 - Functions and methods should accept only the data they use. Prefer passing the
   smallest required values over accepting a broader type such as `&self` when
   the function does not depend on the rest of that type's state.

--- a/rust/src/editor/.main.rs
+++ b/rust/src/editor/.main.rs
@@ -18,9 +18,23 @@ use asset::EditorAssets;
 use editor::Editor;
 use gpui::{App, Bounds, WindowBounds, WindowOptions, prelude::*, px, rgb, size};
 use gpui_platform::application;
+use std::io::Write as _;
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("opencut_editor=debug"),
+    )
+    .format(|buffer, record| {
+        writeln!(
+            buffer,
+            "{}\n\t\t[{}:{}]",
+            record.args(),
+            record.file().unwrap_or("<unknown>"),
+            record.line().unwrap_or(0)
+        )
+    })
+    .init();
+
     macos_pinch::install();
     application().with_assets(EditorAssets).run(run_app);
 }

--- a/rust/src/editor/explorer.rs
+++ b/rust/src/editor/explorer.rs
@@ -463,7 +463,7 @@ impl Editor {
                             .child(rename_dialog_button("Create", true).on_click(cx.listener(
                                 |editor, _, _, cx| {
                                     if let Err(error) = editor.finish_create_timeline(cx) {
-                                        eprintln!("{error}");
+                                        eprintln!("{error:?}");
                                     }
                                     cx.notify();
                                 },

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -386,7 +386,7 @@ impl Editor {
             self.schedule_active_timeline_waveforms(cx);
             Ok(())
         })();
-        eprintln!("activate_timeline: {}", t.elapsed().as_millis());
+        log::debug!("activate_timeline: {}", t.elapsed().as_millis());
         res.context("activate_timeline failed")
     }
 

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -338,7 +338,8 @@ impl Editor {
         active_timeline: TimelineSerialization,
         cx: &mut Context<Self>,
     ) -> Result<()> {
-        (|| -> Result<()> {
+        let t = Instant::now();
+        let res = (|| -> Result<()> {
             self.preview.volume_control_open = false;
             self.preview.is_scrubbing = false;
             self.preview.is_adjusting_volume = false;
@@ -384,8 +385,9 @@ impl Editor {
             }
             self.schedule_active_timeline_waveforms(cx);
             Ok(())
-        })()
-        .context("activate_timeline failed")
+        })();
+        eprintln!("activate_timeline: {}", t.elapsed().as_millis());
+        res.context("activate_timeline failed")
     }
 
     fn schedule_project_waveforms(&mut self, cx: &mut Context<Self>) {

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -371,7 +371,8 @@ impl Editor {
                 self.timeline.as_ref().map(|timeline| timeline.path.clone());
             self.dismiss_context_menu();
             self.explorer
-                .refresh_file_tree(&self.global_settings.project_root)?;
+                .refresh_file_tree(&self.global_settings.project_root)
+                .context("refresh_file_tree failed")?;
             if let Some(timeline) = self.timeline.as_mut()
                 && !timeline.data.clips.is_empty()
             {

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -430,8 +430,7 @@ impl TimelineRuntimeState {
         Ok(Self {
             path,
             data,
-            video_backend: TimelineVideoBackend::new(ges_timeline)
-                .context("TimelineVideoBackend::new failed")?,
+            video_backend: TimelineVideoBackend::new(ges_timeline)?,
             playhead,
             interaction: TimelineInteractionState {
                 active_tool: TimelineTool::Selection,

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -20,7 +20,7 @@ pub struct TimelineVideoBackend {
 impl TimelineVideoBackend {
     pub fn new(ges_timeline: ges::Timeline) -> Result<TimelineVideoBackend> {
         let playback =
-            create_timeline_playback(&ges_timeline).context("create_timeline_playback failed")?;
+            create_timeline_playback(&ges_timeline).context("TimelineVideoBackend::new failed")?;
         Ok(Self {
             ges_timeline,
             playback,

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -39,7 +39,9 @@ impl VideoBackend {
         sink: gst_app::AppSink,
         volume_control: gst_audio::StreamVolume,
     ) -> Result<Self> {
-        gst::init().context("could not initialize GStreamer")?;
+        gst::init().with_context(|| {
+            format!("could not initialize GStreamer at {}:{}", file!(), line!())
+        })?;
         let current_frame = Arc::new(Mutex::new(None));
         sink.set_callbacks(
             gst_app::AppSinkCallbacks::builder()
@@ -63,11 +65,32 @@ impl VideoBackend {
         );
         pipeline
             .set_state(gst::State::Paused)
-            .context("could not prepare video")?;
-        let state = pipeline.state(gst::ClockTime::from_seconds(5));
-        if let Err(error) = state.0 {
-            let _ = pipeline.set_state(gst::State::Null);
-            return Err(Error::new(error).context("video did not finish preparing"));
+            .with_context(|| format!("could not prepare video at {}:{}", file!(), line!()))?;
+        match pipeline.state(gst::ClockTime::ZERO).0 {
+            Ok(gst::StateChangeSuccess::Success) => {}
+            Ok(gst::StateChangeSuccess::Async) => {
+                // Empty and still-preparing pipelines may remain pending without failing.
+                eprintln!("VideoBackend: pipeline state changed to Async");
+            }
+            Ok(gst::StateChangeSuccess::NoPreroll) => {
+                // Live pipelines do not preroll in the paused state.
+                eprintln!("VideoBackend: pipeline state changed to NoPreroll");
+            }
+            Err(error) => {
+                let preparation_error = Error::new(error).context(format!(
+                    "video did not finish preparing at {}:{}",
+                    file!(),
+                    line!()
+                ));
+                if let Err(error) = pipeline.set_state(gst::State::Null) {
+                    return Err(preparation_error.context(format!(
+                        "could not set pipeline to null state after preparation failed at {}:{}: {error}",
+                        file!(),
+                        line!()
+                    )));
+                }
+                return Err(preparation_error);
+            }
         }
         let caps = sink
             .static_pad("sink")
@@ -79,9 +102,11 @@ impl VideoBackend {
                     Ok(info) => info,
                     Err(error) => {
                         let _ = pipeline.set_state(gst::State::Null);
-                        return Err(
-                            Error::new(error).context("video caps did not describe raw video")
-                        );
+                        return Err(Error::new(error).context(format!(
+                            "video caps did not describe raw video at {}:{}",
+                            file!(),
+                            line!()
+                        )));
                     }
                 };
                 (info.width(), info.height())

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -63,22 +63,19 @@ impl VideoBackend {
                 })
                 .build(),
         );
-        pipeline
-            .set_state(gst::State::Paused)
-            .with_context(|| format!("could not prepare video at {}:{}", file!(), line!()))?;
-        match pipeline.state(gst::ClockTime::ZERO).0 {
+        match pipeline.set_state(gst::State::Paused) {
             Ok(gst::StateChangeSuccess::Success) => {}
             Ok(gst::StateChangeSuccess::Async) => {
                 // Empty and still-preparing pipelines may remain pending without failing.
-                eprintln!("VideoBackend: pipeline state changed to Async");
+                log::debug!("video pipeline is preparing asynchronously");
             }
             Ok(gst::StateChangeSuccess::NoPreroll) => {
                 // Live pipelines do not preroll in the paused state.
-                eprintln!("VideoBackend: pipeline state changed to NoPreroll");
+                log::debug!("live video pipeline does not preroll");
             }
             Err(error) => {
                 let preparation_error = Error::new(error).context(format!(
-                    "video did not finish preparing at {}:{}",
+                    "could not prepare video at {}:{}",
                     file!(),
                     line!()
                 ));

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use anyhow::{Context as _, Error, Result, anyhow, bail};
+use anyhow::{Context as _, Error, Result, anyhow};
 use gst::prelude::*;
 
 use gst_audio::prelude::StreamVolumeExt as _;
@@ -64,28 +64,30 @@ impl VideoBackend {
         pipeline
             .set_state(gst::State::Paused)
             .context("could not prepare video")?;
-        if let Err(error) = pipeline.state(gst::ClockTime::from_seconds(5)).0 {
+        let state = pipeline.state(gst::ClockTime::from_seconds(5));
+        if let Err(error) = state.0 {
             let _ = pipeline.set_state(gst::State::Null);
             return Err(Error::new(error).context("video did not finish preparing"));
         }
-        let Some(caps) = sink
+        let caps = sink
             .static_pad("sink")
             .expect("AppSink must have a static sink pad")
-            .current_caps()
-        else {
-            if let Err(err) = pipeline.set_state(gst::State::Null) {
-                return Err(Error::new(err).context("could not set pipeline to null state"));
+            .current_caps();
+        let frame_size = match caps {
+            Some(caps) => {
+                let info = match gst_video::VideoInfo::from_caps(&caps) {
+                    Ok(info) => info,
+                    Err(error) => {
+                        let _ = pipeline.set_state(gst::State::Null);
+                        return Err(
+                            Error::new(error).context("video caps did not describe raw video")
+                        );
+                    }
+                };
+                (info.width(), info.height())
             }
-            bail!("video caps were not negotiated at {}:{}", file!(), line!());
+            None => (1, 1),
         };
-        let info = match gst_video::VideoInfo::from_caps(&caps) {
-            Ok(info) => info,
-            Err(error) => {
-                let _ = pipeline.set_state(gst::State::Null);
-                return Err(Error::new(error).context("video caps did not describe raw video"));
-            }
-        };
-        let frame_size = (info.width(), info.height());
 
         // GStreamer negotiates `framerate=0/1` for variable-frame-rate sources such as
         // screen recordings. That is a valid "unknown rate" marker, not a broken file, so
@@ -115,7 +117,11 @@ impl VideoBackend {
     }
 
     pub(crate) fn frame_size(&self) -> (u32, u32) {
-        return self._frame_size;
+        self.cap()
+            .ok()
+            .and_then(|caps| gst_video::VideoInfo::from_caps(&caps).ok())
+            .map(|info| (info.width(), info.height()))
+            .unwrap_or(self._frame_size)
     }
 
     /// The negotiated frame rate, or `None` for variable-frame-rate sources where

--- a/rust/src/video/video_backend.rs
+++ b/rust/src/video/video_backend.rs
@@ -73,8 +73,10 @@ impl VideoBackend {
             .expect("AppSink must have a static sink pad")
             .current_caps()
         else {
-            let _ = pipeline.set_state(gst::State::Null);
-            bail!("video caps were not negotiated");
+            if let Err(err) = pipeline.set_state(gst::State::Null) {
+                return Err(Error::new(err).context("could not set pipeline to null state"));
+            }
+            bail!("video caps were not negotiated at {}:{}", file!(), line!());
         };
         let info = match gst_video::VideoInfo::from_caps(&caps) {
             Ok(info) => info,

--- a/rust/src/video/video_backend.test.rs
+++ b/rust/src/video/video_backend.test.rs
@@ -3,37 +3,43 @@ use std::{path::Path, time::Instant};
 use url::Url;
 
 #[test]
-fn missing_caps_does_not_stop_the_pipeline_or_panic_during_rendering() {
+fn from_pipeline_accepts_an_empty_pipeline_without_caps() {
     gst::init().expect("could not initialize GStreamer");
     let pipeline = gst::Pipeline::new();
     let sink = gst_app::AppSink::builder().build();
     pipeline
         .add(&sink)
         .expect("could not add test sink to pipeline");
-    let volume_control = gst::ElementFactory::make("volume")
-        .build()
-        .expect("could not create test volume control")
-        .dynamic_cast::<gst_audio::StreamVolume>()
-        .expect("test volume element does not implement StreamVolume");
-    let video = VideoBackend {
-        pipeline,
-        sink,
-        volume_control,
-        current_frame: Arc::new(Mutex::new(None)),
-        cached_position: Duration::ZERO,
-        _frame_size: (1, 1),
-    };
-    video
-        .pipeline
-        .set_state(gst::State::Ready)
-        .expect("could not prepare test pipeline");
+    let video = VideoBackend::from_pipeline(pipeline, sink, test_volume_control())
+        .expect("an empty pipeline should create a video backend");
 
     assert_eq!(video.frame_size(), (1, 1));
     let element = crate::video::video(&video);
 
-    assert_eq!(video.pipeline.current_state(), gst::State::Ready);
+    assert_ne!(video.pipeline.current_state(), gst::State::Null);
     assert_eq!(element.width, gpui::px(1.0));
     assert_eq!(element.height, gpui::px(1.0));
+}
+
+#[test]
+fn from_pipeline_reads_negotiated_frame_size() {
+    gst::init().expect("could not initialize GStreamer");
+    let pipeline = gst::parse::launch(
+        "videotestsrc ! video/x-raw,width=320,height=180 ! appsink name=test_video_sink",
+    )
+    .expect("could not create test video pipeline")
+    .downcast::<gst::Pipeline>()
+    .expect("test video pipeline had an unexpected type");
+    let sink = pipeline
+        .by_name("test_video_sink")
+        .expect("test video sink was not created")
+        .downcast::<gst_app::AppSink>()
+        .expect("test video sink had an unexpected type");
+
+    let video = VideoBackend::from_pipeline(pipeline, sink, test_volume_control())
+        .expect("could not create video backend");
+
+    assert_eq!(video.frame_size(), (320, 180));
 }
 
 #[test]
@@ -60,4 +66,12 @@ fn measures_seek_to_half_of_a_video() {
     let elapsed = started_at.elapsed();
 
     eprintln!("FileVideoBackend::seek to 50% ({target:?} of {duration:?}) took {elapsed:?}");
+}
+
+fn test_volume_control() -> gst_audio::StreamVolume {
+    gst::ElementFactory::make("volume")
+        .build()
+        .expect("could not create test volume control")
+        .dynamic_cast::<gst_audio::StreamVolume>()
+        .expect("test volume element does not implement StreamVolume")
 }

--- a/rust/src/video/video_backend.test.rs
+++ b/rust/src/video/video_backend.test.rs
@@ -10,9 +10,14 @@ fn from_pipeline_accepts_an_empty_pipeline_without_caps() {
     pipeline
         .add(&sink)
         .expect("could not add test sink to pipeline");
+    let started_at = Instant::now();
     let video = VideoBackend::from_pipeline(pipeline, sink, test_volume_control())
         .expect("an empty pipeline should create a video backend");
 
+    assert!(
+        started_at.elapsed() < Duration::from_secs(1),
+        "an empty pipeline should not wait for preroll"
+    );
     assert_eq!(video.frame_size(), (1, 1));
     let element = crate::video::video(&video);
 
@@ -38,6 +43,11 @@ fn from_pipeline_reads_negotiated_frame_size() {
 
     let video = VideoBackend::from_pipeline(pipeline, sink, test_volume_control())
         .expect("could not create video backend");
+    video
+        .pipeline
+        .state(gst::ClockTime::from_seconds(5))
+        .0
+        .expect("test video pipeline did not finish preparing");
 
     assert_eq!(video.frame_size(), (320, 180));
 }


### PR DESCRIPTION
## Summary

- Allow `VideoBackend` to initialize when an empty timeline has no negotiated video caps.
- Handle all GStreamer state-change outcomes explicitly without blocking for five seconds.
- Use a temporary 1×1 frame size until real caps become available.
- Improve timeline activation and error diagnostics with source locations.
- Restrict default debug logging to OpenCut modules.
- Add tests for empty pipelines and negotiated frame dimensions.
