### PR TITLE
Update video clip transforms without rebuilding and add image previews

### DIFF
--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1197,11 +1197,18 @@ pub(super) fn edit_timeline(
             clip_ids,
             properties,
         } => {
+            ges_change_video_clip(
+                timeline.video_backend.ges_timeline(),
+                &timeline.data,
+                &clip_ids,
+                properties,
+            )?;
             for clip_id in clip_ids {
                 if let Some(clip) = timeline.data.clip_mut(clip_id).and_then(Clip::media_mut) {
                     clip.video_properties = properties;
                 }
             }
+            return Ok(false);
         }
         EditAction::SetTextProperties {
             clip_id,
@@ -1438,7 +1445,55 @@ fn ges_move_clips(
     Ok(())
 }
 
-// change the text of a text clip in the ges timeline
+fn ges_change_video_clip(
+    ges: &gstreamer_editing_services::Timeline,
+    timeline: &TimelineSerialization,
+    clip_ids: &[Ulid],
+    properties: VideoClipProperties,
+) -> anyhow::Result<()> {
+    use gstreamer_editing_services::prelude::*;
+
+    let options = export::ExportOptions::from_timeline(timeline);
+    for clip_id in clip_ids {
+        let Some(Clip::Video(clip)) = timeline.clip(*clip_id) else {
+            continue;
+        };
+        let Some(asset) = timeline.asset(clip.asset_id) else {
+            anyhow::bail!(
+                "clip {clip_id} has no source media at {}:{}",
+                file!(),
+                line!()
+            );
+        };
+        let name = format!("opencut-clip-{clip_id}");
+        let Some(rendered) = ges
+            .layers()
+            .into_iter()
+            .flat_map(|layer| layer.clips())
+            .find(|clip| clip.name().as_deref() == Some(name.as_str()))
+        else {
+            anyhow::bail!("missing GES clip {clip_id} at {}:{}", file!(), line!());
+        };
+        if let Err(error) = super::export_gstreamer::apply_video_transform(
+            &rendered, timeline, asset, options, properties,
+        ) {
+            return Err(error.context(format!(
+                "could not transform clip {clip_id} at {}:{}",
+                file!(),
+                line!(),
+            )));
+        }
+    }
+    if !ges.commit() {
+        anyhow::bail!(
+            "could not commit video transforms at {}:{}",
+            file!(),
+            line!()
+        );
+    }
+    Ok(())
+}
+
 fn ges_change_text_clip(
     ges: &gstreamer_editing_services::Timeline,
     clip_id: Ulid,

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -1,7 +1,7 @@
 use super::*;
 use super::{
     clip_render_plan::{RenderRect, resolve_visual_clip_render_plan},
-    timeline_video::update_timeline_video_position,
+    timeline_video::{refresh_timeline_video_frame, try_refresh_timeline_video_frame},
 };
 use crate::playback_view::{CONTROL_HEIGHT, format_duration};
 use crate::video::video;
@@ -764,12 +764,9 @@ impl Editor {
             now.duration_since(last_update) >= TIMELINE_TRANSFORM_UPDATE_INTERVAL
         }) {
             drag.last_pipeline_update = Some(now);
-            if let Err(error) = update_timeline_video_position(
-                &mut timeline.video_backend,
-                &timeline.data,
-                drag.clip_id,
-                false,
-            ) {
+            if let Err(error) =
+                try_refresh_timeline_video_frame(timeline.video_backend.playback_mut())
+            {
                 eprintln!("{error}");
             }
         }
@@ -785,12 +782,7 @@ impl Editor {
         };
         if drag.changed {
             if let Some(timeline) = self.timeline.as_mut() {
-                match update_timeline_video_position(
-                    &mut timeline.video_backend,
-                    &timeline.data,
-                    drag.clip_id,
-                    true,
-                ) {
+                match refresh_timeline_video_frame(timeline.video_backend.playback_mut()) {
                     Ok(()) => {}
                     Err(error) => eprintln!("{error}"),
                 }

--- a/rust/src/editor/properties.rs
+++ b/rust/src/editor/properties.rs
@@ -11,8 +11,8 @@ use crate::editor::{
 };
 use gpui::prelude::FluentBuilder;
 use gpui::{
-    Entity, InteractiveElement, IntoElement, ParentElement, StatefulInteractiveElement, Styled,
-    div, px, rgb,
+    Entity, InteractiveElement, IntoElement, ObjectFit, ParentElement, StatefulInteractiveElement,
+    Styled, StyledImage, div, img, px, rgb,
 };
 use std::{
     fs,
@@ -25,7 +25,7 @@ pub(super) enum PropertiesPanelViewable<'a> {
     TextClip(&'a TextClip),
     VideoFile(&'a Path),
     AudioFile(&'a Path),
-    ImageFile(&'a Path),
+    ImageFile(PathBuf),
     SrtFile(PathBuf),
     TimelineFile(&'a TimelineRuntimeState),
     None,
@@ -53,7 +53,9 @@ pub fn current_properties_panel_viewable(editor: &Editor) -> PropertiesPanelView
             return PropertiesPanelViewable::AudioFile(path);
         }
         if is_image_path(path) {
-            return PropertiesPanelViewable::ImageFile(path);
+            return PropertiesPanelViewable::ImageFile(
+                editor.global_settings.project_root.join(path),
+            );
         }
         if is_srt_path(path) {
             return PropertiesPanelViewable::SrtFile(
@@ -89,7 +91,8 @@ pub(super) fn properties_panel(
         PropertiesPanelViewable::AudioClip(clip) => audio_clip(clip),
         PropertiesPanelViewable::VideoFile(file) => video_file(file),
         PropertiesPanelViewable::TimelineFile(timeline) => timeline_file(timeline),
-        PropertiesPanelViewable::AudioFile(path) | PropertiesPanelViewable::ImageFile(path) => {
+        PropertiesPanelViewable::ImageFile(path) => image_file(path),
+        PropertiesPanelViewable::AudioFile(path) => {
             let _ = path;
             panic!("not implemented")
         }
@@ -100,6 +103,58 @@ pub(super) fn properties_panel(
             .child("No properties available")
             .into_any_element(),
     }
+}
+
+fn image_file(path: PathBuf) -> gpui::AnyElement {
+    let name = path
+        .file_name()
+        .unwrap_or(path.as_os_str())
+        .to_string_lossy()
+        .into_owned();
+
+    div()
+        .id("image-file-properties")
+        .h_full()
+        .min_h_0()
+        .flex()
+        .flex_col()
+        .overflow_hidden()
+        .bg(rgb(PANEL))
+        .child(
+            div()
+                .h(px(58.0))
+                .flex_shrink_0()
+                .flex()
+                .items_center()
+                .px_5()
+                .border_b_1()
+                .border_color(rgb(BORDER))
+                .child(properties_tab("Image", true)),
+        )
+        .child(
+            div()
+                .px_5()
+                .py_3()
+                .flex_shrink_0()
+                .text_sm()
+                .text_ellipsis()
+                .child(name),
+        )
+        .child(
+            div()
+                .relative()
+                .flex_1()
+                .min_h_0()
+                .overflow_hidden()
+                .bg(rgb(SURFACE))
+                .child(
+                    img(path)
+                        .absolute()
+                        .size_full()
+                        .object_fit(ObjectFit::Contain),
+                ),
+        )
+        .into_any_element()
 }
 
 fn timeline_file(timeline: &TimelineRuntimeState) -> gpui::AnyElement {

--- a/rust/src/editor/properties_transform.rs
+++ b/rust/src/editor/properties_transform.rs
@@ -158,6 +158,11 @@ impl Editor {
         )
         .expect("setting video properties cannot be rejected");
 
+        if let Err(error) = super::timeline_video::refresh_timeline_video_frame(
+            timeline.video_backend.playback_mut(),
+        ) {
+            log::error!("{error:#}");
+        }
         timeline.save(&self.global_settings.project_root);
     }
 }

--- a/rust/src/editor/tests/editing.test.rs
+++ b/rust/src/editor/tests/editing.test.rs
@@ -296,7 +296,12 @@ fn moves_ges_clip_without_rebuilding_timeline() {
         .unwrap();
     let expected_start = project.duration(start);
     // Text starts one nanosecond before the frame boundary to avoid a title gap.
-    assert!(clip.start().nseconds().abs_diff(expected_start.as_nanos() as u64) <= 1);
+    assert!(
+        clip.start()
+            .nseconds()
+            .abs_diff(expected_start.as_nanos() as u64)
+            <= 1
+    );
 
     let background = ges
         .layers()
@@ -373,14 +378,16 @@ fn moves_adjacent_ges_clips_together_without_transient_overlap() {
         })
         .collect::<HashMap<_, _>>();
     assert!(
-        starts[&first_clip_id].nseconds().abs_diff(
-            project.duration(TimelineTime::from_frames(60)).as_nanos() as u64
-        ) <= 1
+        starts[&first_clip_id]
+            .nseconds()
+            .abs_diff(project.duration(TimelineTime::from_frames(60)).as_nanos() as u64)
+            <= 1
     );
     assert!(
-        starts[&second_clip_id].nseconds().abs_diff(
-            project.duration(TimelineTime::from_frames(120)).as_nanos() as u64
-        ) <= 1
+        starts[&second_clip_id]
+            .nseconds()
+            .abs_diff(project.duration(TimelineTime::from_frames(120)).as_nanos() as u64)
+            <= 1
     );
 }
 
@@ -430,7 +437,10 @@ fn moves_adjacent_ges_clips_beyond_timeline_end_without_parking_overlap() {
 
     let mut runtime =
         TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone()).unwrap();
-    assert_eq!(runtime.data.content_duration(), TimelineTime::from_frames(150));
+    assert_eq!(
+        runtime.data.content_duration(),
+        TimelineTime::from_frames(150)
+    );
     edit_timeline(
         &mut runtime,
         Path::new(env!("CARGO_MANIFEST_DIR")),
@@ -648,5 +658,78 @@ fn detects_timeline_and_ges_data_divergence() {
     assert!(
         error.to_string().contains("starts at"),
         "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn updates_video_transform_without_rebuilding_ges_clip() {
+    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
+    gstreamer_editing_services::init().unwrap();
+    let mut project = TimelineSerialization::with_test_tracks();
+    project.settings.width = 1920;
+    project.settings.height = 1080;
+    let mut asset = audio_asset(100);
+    asset.kind = MediaKind::Video;
+    asset.width = 1920;
+    asset.height = 1080;
+    project.assets.push(asset);
+    let Clip::Audio(mut media) = audio_clip(10, 0, 60) else {
+        unreachable!();
+    };
+    media.track_id = ulid(1);
+    project.clips.push(Clip::Video(media));
+    let ges = gstreamer_editing_services::Timeline::new_audio_video();
+    let layer = ges.append_layer();
+    let rendered = gstreamer_editing_services::TestClip::new().unwrap();
+    rendered.set_supported_formats(gstreamer_editing_services::TrackType::VIDEO);
+    rendered
+        .set_name(Some(&format!("opencut-clip-{}", ulid(10))))
+        .unwrap();
+    assert!(rendered.set_duration(gstreamer::ClockTime::from_seconds(2)));
+    layer.add_clip(&rendered).unwrap();
+    let mut runtime =
+        TimelineRuntimeState::new("test.timeline.json".into(), project, ges.clone()).unwrap();
+    let properties = VideoClipProperties {
+        position_x: 120.0,
+        position_y: 60.0,
+        scale: 0.5,
+    };
+    let rebuild = edit_timeline(
+        &mut runtime,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        EditAction::SetVideoProperties {
+            clip_ids: vec![ulid(10)],
+            properties,
+        },
+    )
+    .unwrap();
+    assert!(!rebuild);
+    assert_eq!(runtime.video_backend.ges_timeline(), &ges);
+    assert_eq!(
+        layer.clips()[0],
+        rendered
+            .clone()
+            .upcast::<gstreamer_editing_services::Clip>()
+    );
+    for (name, expected) in [
+        ("posx", 600),
+        ("posy", 330),
+        ("width", 960),
+        ("height", 540),
+    ] {
+        assert_eq!(
+            rendered.child_property(name).unwrap().get::<i32>().unwrap(),
+            expected
+        );
+    }
+    assert_eq!(
+        runtime
+            .data
+            .clip(ulid(10))
+            .unwrap()
+            .media()
+            .unwrap()
+            .video_properties,
+        properties
     );
 }

--- a/rust/src/editor/tests/timeline_video.test.rs
+++ b/rust/src/editor/tests/timeline_video.test.rs
@@ -1,0 +1,43 @@
+use super::*;
+use std::time::{Duration, Instant};
+
+#[test]
+fn repeated_drag_refreshes_allow_slow_frames_to_finish() {
+    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
+    ges::init().unwrap();
+    let pipeline = gst::parse::launch(
+        "videotestsrc name=source pattern=black num-buffers=300 ! video/x-raw,format=RGBA,width=16,height=16,framerate=30/1 ! identity sleep-time=50000 ! appsink name=sink",
+    ).unwrap().downcast::<gst::Pipeline>().unwrap();
+    let sink = pipeline
+        .by_name("sink")
+        .unwrap()
+        .downcast::<gst_app::AppSink>()
+        .unwrap();
+    let volume = gst::ElementFactory::make("volume")
+        .build()
+        .unwrap()
+        .dynamic_cast::<gst_audio::StreamVolume>()
+        .unwrap();
+    let mut playback = VideoBackend::from_pipeline(pipeline.clone(), sink, volume).unwrap();
+    pipeline.state(gst::ClockTime::from_seconds(5)).0.unwrap();
+    let initial = playback.get_current_frame().unwrap();
+    assert_eq!(
+        initial.buffer().unwrap().map_readable().unwrap().as_slice()[0],
+        0
+    );
+    pipeline
+        .by_name("source")
+        .unwrap()
+        .set_property_from_str("pattern", "white");
+
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(2) {
+        try_refresh_timeline_video_frame(&mut playback).unwrap();
+        std::thread::sleep(Duration::from_millis(16));
+        let frame = playback.get_current_frame().unwrap();
+        if frame.buffer().unwrap().map_readable().unwrap().as_slice()[0] == 255 {
+            return;
+        }
+    }
+    panic!("new pixels never arrived while drag refreshes continued");
+}

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -1,7 +1,3 @@
-use super::{
-    clip_render_plan::resolve_visual_clip_render_plan, export::ExportOptions,
-    timeline::TimelineSerialization,
-};
 use crate::video::VideoBackend;
 use anyhow::{Context as _, Result};
 use ges::prelude::*;
@@ -9,8 +5,6 @@ use gstreamer as gst;
 use gstreamer_app as gst_app;
 use gstreamer_audio as gst_audio;
 use gstreamer_editing_services as ges;
-
-use ulid::Ulid;
 
 pub struct TimelineVideoBackend {
     ges_timeline: ges::Timeline,
@@ -40,68 +34,33 @@ impl TimelineVideoBackend {
     }
 }
 
-pub(super) fn update_timeline_video_position(
-    video: &mut TimelineVideoBackend,
-    timeline_data: &TimelineSerialization,
-    clip_id: Ulid,
-    refresh_frame: bool,
-) -> anyhow::Result<()> {
-    let clip = timeline_data
-        .clip(clip_id)
-        .ok_or_else(|| anyhow::anyhow!("Clip {clip_id} is unavailable."))?;
-    let clip = clip
-        .media()
-        .ok_or_else(|| anyhow::anyhow!("Clip {clip_id} is not a media clip."))?;
-    let asset = timeline_data
-        .asset(clip.asset_id)
-        .ok_or_else(|| anyhow::anyhow!("Clip {clip_id} has no source media."))?;
-    let timeline = &video.ges_timeline;
-    let clip_name = format!("opencut-clip-{clip_id}");
-    let rendered_clip = timeline
-        .layers()
-        .into_iter()
-        .flat_map(|layer| layer.clips())
-        .find(|rendered_clip| rendered_clip.name().as_deref() == Some(clip_name.as_str()))
-        .ok_or_else(|| anyhow::anyhow!("timeline preview has no rendered clip for {clip_id}"))?;
-    let options = ExportOptions::from_timeline(timeline_data);
-    let plan = resolve_visual_clip_render_plan(
-        clip.video_properties,
-        asset.width,
-        asset.height,
-        timeline_data.settings.width,
-        timeline_data.settings.height,
-        options.width.max(2) as f64,
-        options.height.max(2) as f64,
-    );
-    for (name, value) in [
-        (
-            "posx",
-            plan.visible
-                .left
-                .round()
-                .clamp(i32::MIN as f64, i32::MAX as f64) as i32,
-        ),
-        (
-            "posy",
-            plan.visible
-                .top
-                .round()
-                .clamp(i32::MIN as f64, i32::MAX as f64) as i32,
-        ),
-    ] {
-        rendered_clip
-            .set_child_property(name, value)
-            .map_err(|error| anyhow::anyhow!("could not update preview video {name}: {error}"))?;
-    }
-    if !refresh_frame {
-        return Ok(());
-    }
-    if !timeline.commit_sync() {
-        anyhow::bail!("GStreamer could not commit the preview position.");
-    }
-    let playback = &mut video.playback;
+pub fn refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::Result<()> {
     let position = playback.position();
-    playback.seek(position)
+    playback.seek(position).with_context(|| {
+        format!(
+            "could not refresh timeline preview at {}:{}",
+            file!(),
+            line!()
+        )
+    })
+}
+
+pub fn try_refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::Result<()> {
+    // A flushing seek cancels pending preroll. Let that frame reach the sink
+    // before requesting another one, even when mouse events arrive faster.
+    let (result, _, _) = playback.pipeline().state(gst::ClockTime::ZERO);
+    match result {
+        Ok(gst::StateChangeSuccess::Async) => return Ok(()),
+        Err(error) => {
+            anyhow::bail!(
+                "preview pipeline could not finish rendering: {error} at {}:{}",
+                file!(),
+                line!(),
+            );
+        }
+        _ => {}
+    }
+    refresh_timeline_video_frame(playback)
 }
 
 pub fn create_timeline_pipeline_v2(
@@ -161,3 +120,7 @@ fn preview_audio_sink() -> anyhow::Result<(gst::Element, gst_audio::StreamVolume
         .map_err(|_| anyhow::anyhow!("timeline preview volume control has an unexpected type"))?;
     Ok((sink.upcast(), control))
 }
+
+#[cfg(test)]
+#[path = "tests/timeline_video.test.rs"]
+mod tests;


### PR DESCRIPTION
Video position and scale changes now update existing GES clips without rebuilding the timeline or playback pipeline. Canvas dragging requests preview frames without interrupting pending renders, with a final refresh on release. Transform-field edits also refresh the preview.

Selecting an image file now displays its filename and an aspect-ratio-preserving preview instead of panicking.