### PR TITLE
Add preview resizing and snapping

### DIFF
--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1484,13 +1484,8 @@ fn ges_change_video_clip(
             )));
         }
     }
-    if !ges.commit() {
-        anyhow::bail!(
-            "could not commit video transforms at {}:{}",
-            file!(),
-            line!()
-        );
-    }
+    // Child transform properties apply directly; a timeline commit is only
+    // needed for structural edits and can restart preroll during dragging.
     Ok(())
 }
 

--- a/rust/src/editor/preview.rs
+++ b/rust/src/editor/preview.rs
@@ -105,20 +105,19 @@ impl Editor {
                 let Some(timeline) = self.timeline.as_mut() else {
                     return;
                 };
-                let video = timeline.video_backend.playback();
-                let is_paused = video.paused();
+                let is_paused = timeline.video_backend.playback().paused();
                 if timeline.data.clips.is_empty() {
                     return;
                 }
 
-                let duration = timeline.data.content_duration();
-                let start = if timeline.playhead() >= duration {
-                    TimelineTime::ZERO
-                } else {
-                    timeline.playhead()
-                };
-                video.set_paused(!is_paused);
-                load_timeline_position_with_options(&mut self.preview, timeline, start);
+                if is_paused && timeline.playhead() >= timeline.data.content_duration() {
+                    load_timeline_position_with_options(
+                        &mut self.preview,
+                        timeline,
+                        TimelineTime::ZERO,
+                    );
+                }
+                timeline.video_backend.playback().set_paused(!is_paused);
             }
         }
     }

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -92,6 +92,49 @@ pub fn preview_timeline_view(
         }
     }
 
+    let mut resize_handles = Vec::new();
+    if let Some(rect) = selected_rect
+        && let Some(clip_id) = timeline.interaction.selected_clip_id
+        && !timeline.data.clip_locked(clip_id)
+    {
+        for (horizontal, vertical) in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
+            let x = rect.left + (horizontal + 1.0) * rect.width * 0.5;
+            let y = rect.top + (vertical + 1.0) * rect.height * 0.5;
+            resize_handles.push(
+                div()
+                    .absolute()
+                    .left(px(x as f32 - 6.0))
+                    .top(px(y as f32 - 6.0))
+                    .size(px(12.0))
+                    .bg(rgb(ACCENT))
+                    .border_1()
+                    .border_color(rgb(0x101012))
+                    .cursor(if horizontal == vertical {
+                        CursorStyle::ResizeUpLeftDownRight
+                    } else {
+                        CursorStyle::ResizeUpRightDownLeft
+                    })
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |editor, event, _, cx| {
+                            editor.begin_timeline_preview_clip_drag(
+                                event,
+                                origin_x,
+                                origin_y,
+                                canvas,
+                                PreviewDragMode::Resize {
+                                    rect,
+                                    horizontal,
+                                    vertical,
+                                },
+                                cx,
+                            );
+                        }),
+                    ),
+            );
+        }
+    }
+
     let duration = timeline.data.duration(timeline.data.content_duration());
     let position = timeline.video_backend.playback().position();
     let progress = if duration.is_zero() {
@@ -184,6 +227,7 @@ pub fn preview_timeline_view(
                                 origin_x,
                                 origin_y,
                                 canvas,
+                                PreviewDragMode::Move,
                                 cx,
                             );
                         }),
@@ -230,7 +274,8 @@ pub fn preview_timeline_view(
                             .border_color(rgb(ACCENT)),
                     )
                 })
-                .children(clip_cursor_regions),
+                .children(clip_cursor_regions)
+                .children(resize_handles),
         )
         .child(
             div()
@@ -559,13 +604,47 @@ pub(super) struct TimelinePreviewDrag {
     clip_id: Ulid,
     pointer_x: f32,
     pointer_y: f32,
-    position_x: f64,
-    position_y: f64,
+    properties: VideoClipProperties,
+    mode: PreviewDragMode,
     canvas: TimelinePreviewCanvas,
     snap_x: Option<f64>,
     snap_y: Option<f64>,
     last_pipeline_update: Option<Instant>,
     changed: bool,
+}
+
+#[derive(Clone, Copy)]
+enum PreviewDragMode {
+    Move,
+    Resize {
+        rect: RenderRect,
+        horizontal: f64,
+        vertical: f64,
+    },
+}
+
+fn resized_preview_properties(
+    original: VideoClipProperties,
+    rect: RenderRect,
+    corner: (f64, f64),
+    delta: (f64, f64),
+    project_scale: f64,
+) -> VideoClipProperties {
+    let diagonal_squared = rect.width * rect.width + rect.height * rect.height;
+    if diagonal_squared <= f64::EPSILON || original.scale <= f64::EPSILON {
+        return original;
+    }
+    let factor = 1.0
+        + (delta.0 * corner.0 * rect.width + delta.1 * corner.1 * rect.height) / diagonal_squared;
+    let scale = (original.scale * factor).clamp(0.01, 100.0);
+    let factor = scale / original.scale;
+    VideoClipProperties {
+        position_x: original.position_x
+            + corner.0 * rect.width * (factor - 1.0) * 0.5 / project_scale,
+        position_y: original.position_y
+            + corner.1 * rect.height * (factor - 1.0) * 0.5 / project_scale,
+        scale,
+    }
 }
 
 fn nearest_canvas_snap(clip_anchors: [f64; 3], canvas_guides: [f64; 3]) -> Option<(f64, f64)> {
@@ -624,6 +703,7 @@ impl Editor {
         surface_left: f32,
         surface_top: f32,
         canvas: TimelinePreviewCanvas,
+        mode: PreviewDragMode,
         cx: &mut Context<Self>,
     ) {
         self.preview.volume_control_open = false;
@@ -632,27 +712,32 @@ impl Editor {
         let Some(timeline) = self.timeline.as_ref() else {
             return;
         };
-        let clip_id = timeline.data.tracks.iter().rev().find_map(|track| {
-            timeline.data.clips_on_track(track.id).find_map(|clip| {
-                let media = clip.media()?;
-                if clip.timeline_start() > timeline.playhead()
-                    || timeline.playhead() >= clip.timeline_end(timeline.data.settings.frame_rate)
-                {
-                    return None;
-                }
-                let rect = timeline_preview_clip_rect(
-                    &timeline.data,
-                    clip,
-                    media.video_properties,
-                    canvas,
-                )?;
-                (f64::from(pointer_x) >= rect.left
-                    && f64::from(pointer_x) <= rect.left + rect.width
-                    && f64::from(pointer_y) >= rect.top
-                    && f64::from(pointer_y) <= rect.top + rect.height)
-                    .then_some(clip.id())
+        let clip_id = if matches!(mode, PreviewDragMode::Resize { .. }) {
+            timeline.interaction.selected_clip_id
+        } else {
+            timeline.data.tracks.iter().rev().find_map(|track| {
+                timeline.data.clips_on_track(track.id).find_map(|clip| {
+                    let media = clip.media()?;
+                    if clip.timeline_start() > timeline.playhead()
+                        || timeline.playhead()
+                            >= clip.timeline_end(timeline.data.settings.frame_rate)
+                    {
+                        return None;
+                    }
+                    let rect = timeline_preview_clip_rect(
+                        &timeline.data,
+                        clip,
+                        media.video_properties,
+                        canvas,
+                    )?;
+                    (f64::from(pointer_x) >= rect.left
+                        && f64::from(pointer_x) <= rect.left + rect.width
+                        && f64::from(pointer_y) >= rect.top
+                        && f64::from(pointer_y) <= rect.top + rect.height)
+                        .then_some(clip.id())
+                })
             })
-        });
+        };
         self.select_only_clip(clip_id);
         let Some(clip_id) = clip_id else {
             self.preview.timeline_drag = None;
@@ -679,8 +764,8 @@ impl Editor {
             clip_id,
             pointer_x: f32::from(event.position.x),
             pointer_y: f32::from(event.position.y),
-            position_x: clip.video_properties.position_x,
-            position_y: clip.video_properties.position_y,
+            properties: clip.video_properties,
+            mode,
             canvas,
             snap_x: None,
             snap_y: None,
@@ -704,10 +789,10 @@ impl Editor {
             self.preview.timeline_drag = Some(drag);
             return true;
         }
-        let position_x = drag.position_x
-            + f64::from(f32::from(event.position.x) - drag.pointer_x) / drag.canvas.project_scale;
-        let position_y = drag.position_y
-            + f64::from(f32::from(event.position.y) - drag.pointer_y) / drag.canvas.project_scale;
+        let delta = (
+            f64::from(f32::from(event.position.x) - drag.pointer_x),
+            f64::from(f32::from(event.position.y) - drag.pointer_y),
+        );
         let Some(timeline) = self.timeline.as_ref() else {
             return true;
         };
@@ -718,15 +803,31 @@ impl Editor {
             return true;
         };
         let current_properties = current_clip.video_properties;
-        let mut properties = current_properties;
-        properties.position_x = position_x;
-        properties.position_y = position_y;
-        let snap_rect = self
-            .timeline
-            .as_ref()
-            .expect("timeline preview drag requires an active timeline")
-            .interaction
-            .snapping_enabled
+        let mut properties = match drag.mode {
+            PreviewDragMode::Move => VideoClipProperties {
+                position_x: drag.properties.position_x + delta.0 / drag.canvas.project_scale,
+                position_y: drag.properties.position_y + delta.1 / drag.canvas.project_scale,
+                ..drag.properties
+            },
+            PreviewDragMode::Resize {
+                rect,
+                horizontal,
+                vertical,
+            } => resized_preview_properties(
+                drag.properties,
+                rect,
+                (horizontal, vertical),
+                delta,
+                drag.canvas.project_scale,
+            ),
+        };
+        let snap_rect = (matches!(drag.mode, PreviewDragMode::Move)
+            && self
+                .timeline
+                .as_ref()
+                .expect("timeline preview drag requires an active timeline")
+                .interaction
+                .snapping_enabled)
             .then(|| {
                 timeline_preview_clip_rect(
                     &timeline.data,
@@ -775,6 +876,7 @@ impl Editor {
         }
         if (current_properties.position_x - properties.position_x).abs() <= f64::EPSILON
             && (current_properties.position_y - properties.position_y).abs() <= f64::EPSILON
+            && (current_properties.scale - properties.scale).abs() <= f64::EPSILON
         {
             self.preview.timeline_drag = Some(drag);
 

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -589,6 +589,7 @@ pub fn preview_timeline_view(
 const TIMELINE_HORIZONTAL_PADDING: f32 = 22.0;
 const TIMELINE_VOLUME_TRACK_HEIGHT: f32 = 144.0;
 const TIMELINE_VOLUME_TRACK_BOTTOM_OFFSET: f32 = 102.0;
+const PREVIEW_SNAP_DISTANCE_PX: f64 = 4.0;
 const TIMELINE_TRANSFORM_UPDATE_INTERVAL: Duration = Duration::from_millis(16);
 
 #[derive(Clone, Copy, Debug)]
@@ -647,12 +648,75 @@ fn resized_preview_properties(
     }
 }
 
-fn nearest_canvas_snap(clip_anchors: [f64; 3], canvas_guides: [f64; 3]) -> Option<(f64, f64)> {
+fn snap_preview_resize(
+    properties: VideoClipProperties,
+    rect: RenderRect,
+    corner: (f64, f64),
+    project_scale: f64,
+    horizontal_guides: &[f64],
+    vertical_guides: &[f64],
+) -> (VideoClipProperties, Option<f64>, Option<f64>) {
+    let fixed_x = rect.left + (1.0 - corner.0) * rect.width * 0.5;
+    let fixed_y = rect.top + (1.0 - corner.1) * rect.height * 0.5;
+    let mut best_factor: Option<f64> = None;
+    for (fixed, span, guides) in [
+        (fixed_x, corner.0 * rect.width, horizontal_guides),
+        (fixed_y, corner.1 * rect.height, vertical_guides),
+    ] {
+        if span.abs() <= f64::EPSILON {
+            continue;
+        }
+        // The opposite edge is stationary; only the moving edge and center
+        // can constrain the scale without moving the anchored corner.
+        for fraction in [1.0, 0.5] {
+            let anchor = fixed + span * fraction;
+            for &guide in guides {
+                if (guide - anchor).abs() > PREVIEW_SNAP_DISTANCE_PX {
+                    continue;
+                }
+                let factor = (guide - fixed) / (span * fraction);
+                if !(0.01..=100.0).contains(&(properties.scale * factor)) {
+                    continue;
+                }
+                if best_factor.is_none_or(|best| (factor - 1.0).abs() < (best - 1.0).abs()) {
+                    best_factor = Some(factor);
+                }
+            }
+        }
+    }
+    let Some(factor) = best_factor else {
+        return (properties, None, None);
+    };
+    let snapped = VideoClipProperties {
+        position_x: properties.position_x
+            + corner.0 * rect.width * (factor - 1.0) * 0.5 / project_scale,
+        position_y: properties.position_y
+            + corner.1 * rect.height * (factor - 1.0) * 0.5 / project_scale,
+        scale: properties.scale * factor,
+    };
+    let mut snap_x = None;
+    let mut snap_y = None;
+    for fraction in [1.0, 0.5] {
+        for &guide in horizontal_guides {
+            if (fixed_x + corner.0 * rect.width * factor * fraction - guide).abs() < 0.000001 {
+                snap_x = Some(guide);
+            }
+        }
+        for &guide in vertical_guides {
+            if (fixed_y + corner.1 * rect.height * factor * fraction - guide).abs() < 0.000001 {
+                snap_y = Some(guide);
+            }
+        }
+    }
+    (snapped, snap_x, snap_y)
+}
+
+fn nearest_canvas_snap(clip_anchors: [f64; 3], canvas_guides: &[f64]) -> Option<(f64, f64)> {
     let mut nearest = None;
     for clip_anchor in clip_anchors {
-        for canvas_guide in canvas_guides {
+        for &canvas_guide in canvas_guides {
             let delta = canvas_guide - clip_anchor;
-            if delta.abs() <= f64::from(SNAP_DISTANCE_PX)
+            if delta.abs() <= PREVIEW_SNAP_DISTANCE_PX
                 && nearest
                     .is_none_or(|(nearest_delta, _): (f64, f64)| delta.abs() < nearest_delta.abs())
             {
@@ -821,58 +885,95 @@ impl Editor {
                 drag.canvas.project_scale,
             ),
         };
-        let snap_rect = (matches!(drag.mode, PreviewDragMode::Move)
-            && self
-                .timeline
-                .as_ref()
-                .expect("timeline preview drag requires an active timeline")
-                .interaction
-                .snapping_enabled)
-            .then(|| {
-                timeline_preview_clip_rect(
+        drag.snap_x = None;
+        drag.snap_y = None;
+        if timeline.interaction.snapping_enabled {
+            let mut horizontal_guides = vec![
+                drag.canvas.left,
+                drag.canvas.left + drag.canvas.width * 0.5,
+                drag.canvas.left + drag.canvas.width,
+            ];
+            let mut vertical_guides = vec![
+                drag.canvas.top,
+                drag.canvas.top + drag.canvas.height * 0.5,
+                drag.canvas.top + drag.canvas.height,
+            ];
+            for clip in &timeline.data.clips {
+                if clip.id() == drag.clip_id
+                    || clip.timeline_start() > timeline.playhead()
+                    || timeline.playhead() >= clip.timeline_end(timeline.data.settings.frame_rate)
+                {
+                    continue;
+                }
+                let Some(media) = clip.media() else {
+                    continue;
+                };
+                let Some(other) = timeline_preview_clip_rect(
                     &timeline.data,
-                    &timeline.data.clips[index],
-                    properties,
+                    clip,
+                    media.video_properties,
                     drag.canvas,
-                )
-            })
-            .flatten();
-        if let Some(rect) = snap_rect {
-            let horizontal_snap = nearest_canvas_snap(
-                [
-                    rect.left + rect.width * 0.5,
-                    rect.left,
-                    rect.left + rect.width,
-                ],
-                [
-                    drag.canvas.left + drag.canvas.width * 0.5,
-                    drag.canvas.left,
-                    drag.canvas.left + drag.canvas.width,
-                ],
-            );
-            let vertical_snap = nearest_canvas_snap(
-                [
-                    rect.top + rect.height * 0.5,
-                    rect.top,
-                    rect.top + rect.height,
-                ],
-                [
-                    drag.canvas.top + drag.canvas.height * 0.5,
-                    drag.canvas.top,
-                    drag.canvas.top + drag.canvas.height,
-                ],
-            );
-            drag.snap_x = horizontal_snap.map(|(_, guide)| guide);
-            drag.snap_y = vertical_snap.map(|(_, guide)| guide);
-            if let Some((delta, _)) = horizontal_snap {
-                properties.position_x += delta / drag.canvas.project_scale;
+                ) else {
+                    continue;
+                };
+                horizontal_guides.extend([
+                    other.left,
+                    other.left + other.width * 0.5,
+                    other.left + other.width,
+                ]);
+                vertical_guides.extend([
+                    other.top,
+                    other.top + other.height * 0.5,
+                    other.top + other.height,
+                ]);
             }
-            if let Some((delta, _)) = vertical_snap {
-                properties.position_y += delta / drag.canvas.project_scale;
+            if let Some(rect) = timeline_preview_clip_rect(
+                &timeline.data,
+                &timeline.data.clips[index],
+                properties,
+                drag.canvas,
+            ) {
+                match drag.mode {
+                    PreviewDragMode::Move => {
+                        if let Some((delta, guide)) = nearest_canvas_snap(
+                            [
+                                rect.left + rect.width * 0.5,
+                                rect.left,
+                                rect.left + rect.width,
+                            ],
+                            &horizontal_guides,
+                        ) {
+                            properties.position_x += delta / drag.canvas.project_scale;
+                            drag.snap_x = Some(guide);
+                        }
+                        if let Some((delta, guide)) = nearest_canvas_snap(
+                            [
+                                rect.top + rect.height * 0.5,
+                                rect.top,
+                                rect.top + rect.height,
+                            ],
+                            &vertical_guides,
+                        ) {
+                            properties.position_y += delta / drag.canvas.project_scale;
+                            drag.snap_y = Some(guide);
+                        }
+                    }
+                    PreviewDragMode::Resize {
+                        horizontal,
+                        vertical,
+                        ..
+                    } => {
+                        (properties, drag.snap_x, drag.snap_y) = snap_preview_resize(
+                            properties,
+                            rect,
+                            (horizontal, vertical),
+                            drag.canvas.project_scale,
+                            &horizontal_guides,
+                            &vertical_guides,
+                        );
+                    }
+                }
             }
-        } else {
-            drag.snap_x = None;
-            drag.snap_y = None;
         }
         if (current_properties.position_x - properties.position_x).abs() <= f64::EPSILON
             && (current_properties.position_y - properties.position_y).abs() <= f64::EPSILON

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -53,6 +53,44 @@ pub fn preview_timeline_view(
     let timeline_left = origin_x + TIMELINE_HORIZONTAL_PADDING;
     let volume_track_bottom = origin_y + height - TIMELINE_VOLUME_TRACK_BOTTOM_OFFSET;
     let has_media = !timeline.data.clips.is_empty();
+    let mut clip_cursor_regions = Vec::new();
+    for track in &timeline.data.tracks {
+        for clip in timeline.data.clips_on_track(track.id) {
+            if clip.timeline_start() > timeline.playhead()
+                || timeline.playhead() >= clip.timeline_end(timeline.data.settings.frame_rate)
+            {
+                continue;
+            }
+            let Some(media) = clip.media() else {
+                continue;
+            };
+            let Some(rect) =
+                timeline_preview_clip_rect(&timeline.data, clip, media.video_properties, canvas)
+            else {
+                continue;
+            };
+            let left = rect.left.max(canvas.left);
+            let top = rect.top.max(canvas.top);
+            let right = (rect.left + rect.width).min(canvas.left + canvas.width);
+            let bottom = (rect.top + rect.height).min(canvas.top + canvas.height);
+            if right <= left || bottom <= top {
+                continue;
+            }
+            clip_cursor_regions.push(
+                div()
+                    .absolute()
+                    .left(px(left as f32))
+                    .top(px(top as f32))
+                    .w(px((right - left) as f32))
+                    .h(px((bottom - top) as f32))
+                    .cursor(if track.locked {
+                        CursorStyle::Arrow
+                    } else {
+                        CursorStyle::OpenHand
+                    }),
+            );
+        }
+    }
 
     let duration = timeline.data.duration(timeline.data.content_duration());
     let position = timeline.video_backend.playback().position();
@@ -136,8 +174,9 @@ pub fn preview_timeline_view(
                 .justify_center()
                 .overflow_hidden()
                 .bg(rgb(0x000000))
+                .cursor(CursorStyle::Arrow)
                 .when(has_media, |this| {
-                    this.cursor(CursorStyle::OpenHand).on_mouse_down(
+                    this.on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |editor, event, _, cx| {
                             editor.begin_timeline_preview_clip_drag(
@@ -190,7 +229,8 @@ pub fn preview_timeline_view(
                             .border_1()
                             .border_color(rgb(ACCENT)),
                     )
-                }),
+                })
+                .children(clip_cursor_regions),
         )
         .child(
             div()

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -18,3 +18,57 @@ fn snaps_clip_centers_and_edges_to_canvas_centers_and_edges() {
     );
     assert_eq!(nearest_canvas_snap([20.0, 10.0, 30.0], canvas_guides), None);
 }
+
+#[test]
+fn resizing_each_corner_preserves_aspect_ratio_and_opposite_corner() {
+    use super::{RenderRect, VideoClipProperties, resized_preview_properties};
+    let original = VideoClipProperties {
+        position_x: 20.0,
+        position_y: -10.0,
+        scale: 1.0,
+    };
+    let rect = RenderRect {
+        left: 10.0,
+        top: 30.0,
+        width: 200.0,
+        height: 100.0,
+    };
+    for corner in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
+        let resized = resized_preview_properties(
+            original,
+            rect,
+            corner,
+            (corner.0 * 100.0, corner.1 * 50.0),
+            0.5,
+        );
+        assert_eq!(resized.scale, 1.5);
+        let center_delta_x = (resized.position_x - original.position_x) * 0.5;
+        let center_delta_y = (resized.position_y - original.position_y) * 0.5;
+        assert_eq!(
+            center_delta_x - corner.0 * rect.width * resized.scale / 2.0,
+            -corner.0 * rect.width / 2.0
+        );
+        assert_eq!(
+            center_delta_y - corner.1 * rect.height * resized.scale / 2.0,
+            -corner.1 * rect.height / 2.0
+        );
+    }
+}
+
+#[test]
+fn resizing_past_the_opposite_corner_does_not_flip_the_clip() {
+    use super::{RenderRect, VideoClipProperties, resized_preview_properties};
+    let resized = resized_preview_properties(
+        VideoClipProperties::default(),
+        RenderRect {
+            left: 0.0,
+            top: 0.0,
+            width: 200.0,
+            height: 100.0,
+        },
+        (1.0, 1.0),
+        (-400.0, -200.0),
+        1.0,
+    );
+    assert_eq!(resized.scale, 0.01);
+}

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -5,18 +5,21 @@ fn snaps_clip_centers_and_edges_to_canvas_centers_and_edges() {
     let canvas_guides = [50.0, 0.0, 100.0];
 
     assert_eq!(
-        nearest_canvas_snap([5.0, -10.0, 20.0], canvas_guides),
-        Some((-5.0, 0.0))
+        nearest_canvas_snap([3.0, -10.0, 20.0], &canvas_guides),
+        Some((-3.0, 0.0))
     );
     assert_eq!(
-        nearest_canvas_snap([30.0, 48.0, 60.0], canvas_guides),
+        nearest_canvas_snap([30.0, 48.0, 60.0], &canvas_guides),
         Some((2.0, 50.0))
     );
     assert_eq!(
-        nearest_canvas_snap([95.0, 80.0, 110.0], canvas_guides),
-        Some((5.0, 100.0))
+        nearest_canvas_snap([97.0, 80.0, 110.0], &canvas_guides),
+        Some((3.0, 100.0))
     );
-    assert_eq!(nearest_canvas_snap([20.0, 10.0, 30.0], canvas_guides), None);
+    assert_eq!(
+        nearest_canvas_snap([20.0, 10.0, 30.0], &canvas_guides),
+        None
+    );
 }
 
 #[test]
@@ -71,4 +74,86 @@ fn resizing_past_the_opposite_corner_does_not_flip_the_clip() {
         1.0,
     );
     assert_eq!(resized.scale, 0.01);
+}
+
+#[test]
+fn resize_snaps_all_corners_without_moving_the_opposite_corner() {
+    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
+    for corner in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
+        let rect = RenderRect {
+            left: 100.0,
+            top: 100.0,
+            width: 200.0,
+            height: 100.0,
+        };
+        let fixed_x = rect.left + (1.0 - corner.0) * rect.width / 2.0;
+        let target = fixed_x + corner.0 * 204.0;
+        let (result, x, y) = snap_preview_resize(
+            VideoClipProperties::default(),
+            rect,
+            corner,
+            1.0,
+            &[target],
+            &[],
+        );
+        assert!((result.scale - 1.02).abs() < 1e-9);
+        assert!((result.position_x - corner.0 * 2.0).abs() < 1e-9);
+        assert!((result.position_y - corner.1).abs() < 1e-9);
+        assert_eq!(x, Some(target));
+        assert_eq!(y, None);
+    }
+}
+
+#[test]
+fn resize_snaps_centers_and_only_shows_guides_that_match_final_geometry() {
+    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
+    let rect = RenderRect {
+        left: 0.0,
+        top: 0.0,
+        width: 200.0,
+        height: 100.0,
+    };
+    // Snap the clip center to x=102, which also aligns its bottom with y=102.
+    let (result, x, y) = snap_preview_resize(
+        VideoClipProperties::default(),
+        rect,
+        (1.0, 1.0),
+        1.0,
+        &[102.0],
+        &[102.0],
+    );
+    assert!((result.scale - 1.02).abs() < 1e-9);
+    assert_eq!((x, y), (Some(102.0), Some(102.0)));
+    // A conflicting y target needs more scale correction, so x wins.
+    let (_, x, y) = snap_preview_resize(
+        VideoClipProperties::default(),
+        rect,
+        (1.0, 1.0),
+        1.0,
+        &[202.0],
+        &[104.0],
+    );
+    assert_eq!((x, y), (Some(202.0), None));
+    let original = VideoClipProperties::default();
+    assert_eq!(
+        snap_preview_resize(original, rect, (1.0, 1.0), 1.0, &[400.0], &[400.0]),
+        (original, None, None)
+    );
+}
+
+#[test]
+fn preview_does_not_snap_five_pixels_away() {
+    assert_eq!(nearest_canvas_snap([5.0, 15.0, 25.0], &[0.0]), None);
+    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
+    let properties = VideoClipProperties::default();
+    let rect = RenderRect {
+        left: 0.0,
+        top: 0.0,
+        width: 200.0,
+        height: 100.0,
+    };
+    assert_eq!(
+        snap_preview_resize(properties, rect, (1.0, 1.0), 1.0, &[205.0], &[]),
+        (properties, None, None)
+    );
 }

--- a/rust/src/editor/tests/timeline_video.test.rs
+++ b/rust/src/editor/tests/timeline_video.test.rs
@@ -41,3 +41,49 @@ fn repeated_drag_refreshes_allow_slow_frames_to_finish() {
     }
     panic!("new pixels never arrived while drag refreshes continued");
 }
+
+#[test]
+fn playback_resumes_after_repeated_resize_refreshes() {
+    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
+    ges::init().unwrap();
+    let timeline = ges::Timeline::new_audio_video();
+    let clip = ges::TestClip::new().unwrap();
+    clip.set_supported_formats(ges::TrackType::VIDEO);
+    assert!(clip.set_duration(gst::ClockTime::from_seconds(10)));
+    timeline.append_layer().add_clip(&clip).unwrap();
+    assert!(timeline.commit());
+    let audio_sink = gst::ElementFactory::make("fakesink").build().unwrap();
+    let (pipeline, sink) = create_timeline_pipeline_v2(&timeline, &audio_sink).unwrap();
+    let volume = gst::ElementFactory::make("volume")
+        .build()
+        .unwrap()
+        .dynamic_cast::<gst_audio::StreamVolume>()
+        .unwrap();
+    let mut playback = VideoBackend::from_pipeline(pipeline.clone(), sink, volume).unwrap();
+    pipeline.state(gst::ClockTime::from_seconds(5)).0.unwrap();
+    for round in 0..20 {
+        for step in 0..10 {
+            clip.set_child_property("width", 160 + round * 10 + step)
+                .unwrap();
+            clip.set_child_property("height", 90 + round * 10 + step)
+                .unwrap();
+            // Transform properties apply without a structural timeline commit.
+            try_refresh_timeline_video_frame(&mut playback).unwrap();
+            std::thread::sleep(Duration::from_millis(16));
+        }
+        refresh_timeline_video_frame(&mut playback).unwrap();
+        let position = playback.position();
+        playback.set_paused(false);
+        let started = Instant::now();
+        while playback.position() <= position + Duration::from_millis(50) {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "playback stalled after resize round {round}, state {:?}",
+                pipeline.state(gst::ClockTime::ZERO)
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        playback.set_paused(true);
+        pipeline.state(gst::ClockTime::from_seconds(5)).0.unwrap();
+    }
+}

--- a/rust/src/editor/timeline_interactions.rs
+++ b/rust/src/editor/timeline_interactions.rs
@@ -660,8 +660,9 @@ impl Editor {
         &mut self,
         event: &ScrollWheelEvent,
         _: &mut Window,
-        _: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
+        cx.notify();
         if event.delta.precise() {
             let delta = event.delta.pixel_delta(px(16.0));
             let horizontal = f32::from(delta.x);

--- a/rust/src/editor/timeline_ui.rs
+++ b/rust/src/editor/timeline_ui.rs
@@ -119,7 +119,7 @@ impl Editor {
             .collect::<Vec<_>>();
         let event_bus = self.event_bus.clone();
         let drag_move_event_bus = event_bus.clone();
-        div()
+        let tracks = div()
             .id("timeline-tracks-vertical-scroll")
             .flex_1()
             .min_h_0()
@@ -205,7 +205,7 @@ impl Editor {
                                             cx.notify();
                                         }),
                                     )
-                                    .child(self.timeline_ruler(duration, cx))
+                                    .child(div().h(px(RULER_HEIGHT)).flex_shrink_0())
                                     .children(track_rows)
                                     .child(self.timeline_playhead(cx))
                                     .when_some(timeline.interaction.snap_guide, |this, guide| {
@@ -281,6 +281,53 @@ impl Editor {
                                             )
                                         },
                                     ),
+                            ),
+                    ),
+            )
+            .into_any_element();
+        div()
+            .relative()
+            .flex_1()
+            .min_h_0()
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .child(tracks)
+            .child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left_0()
+                    .w_full()
+                    .h(px(RULER_HEIGHT))
+                    .flex()
+                    .occlude()
+                    .bg(rgb(0x0a0a0c))
+                    .child(
+                        div()
+                            .w(px(TRACK_HEADER_WIDTH))
+                            .h_full()
+                            .flex_shrink_0()
+                            .border_r_1()
+                            .border_b_1()
+                            .border_color(rgb(BORDER)),
+                    )
+                    .child(
+                        div()
+                            .relative()
+                            .flex_1()
+                            .min_w_0()
+                            .h_full()
+                            .overflow_hidden()
+                            .child(
+                                div()
+                                    .absolute()
+                                    .left(timeline.h_scroll.offset().x)
+                                    .top_0()
+                                    .w(px(timeline_width))
+                                    .h_full()
+                                    .child(self.timeline_ruler(duration, cx))
+                                    .child(self.timeline_playhead(cx)),
                             ),
                     ),
             )

--- a/rust/src/editor/timeline_ui.rs
+++ b/rust/src/editor/timeline_ui.rs
@@ -124,6 +124,7 @@ impl Editor {
             .flex_1()
             .min_h_0()
             .overflow_y_scroll()
+            .restrict_scroll_to_axis()
             .track_scroll(&timeline.v_scroll)
             .on_mouse_down(
                 MouseButton::Left,
@@ -164,6 +165,7 @@ impl Editor {
                             .flex_1()
                             .h_full()
                             .overflow_x_scroll()
+                            .restrict_scroll_to_axis()
                             .track_scroll(&timeline.h_scroll)
                             .cursor(match timeline.interaction.active_tool {
                                 TimelineTool::Blade => CursorStyle::Crosshair,


### PR DESCRIPTION
- Add corner resize handles that preserve aspect ratio and anchor the opposite corner.
- Snap moves and resizes to frame borders, centers, and other visible clips, using a 4-pixel threshold.
- Show the hand cursor only over visible, unlocked clips.
- Keep the ruler fixed during vertical scrolling and restrict scroll gestures to one axis.
- Fix playback failures after repeated resizing by removing unnecessary transform commits and play/pause seeks.