### PR TITLE
Add in-memory timeline transcription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@
   functions instead of logging it there. Log the error only at the highest-level
   application, event, or task boundary.
 - Always use debug formatting (`{error:?}`) when logging errors.
+- Import anyhow helpers explicitly and use unqualified names such as `anyhow!`,
+  `bail!`, `Result`, and `Error`. Use an import alias when a name conflicts with
+  another type. Do not change vendored dependency code to enforce this rule.
 - When refactoring or adding error-handling code, always include `file!()` and
   `line!()` information in every newly added error context.
 - Functions and methods should accept only the data they use. Prefer passing the

--- a/rust/src/cli/README.md
+++ b/rust/src/cli/README.md
@@ -170,7 +170,9 @@ dependencies. The CLI retains a re-export for existing callers.
 use opencut_player::transcribe::{self as transcribe, Format, Options};
 use std::path::Path;
 
-async fn example(api_key: &str) -> anyhow::Result<()> {
+use anyhow::Result;
+
+async fn example(api_key: &str) -> Result<()> {
     let result = transcribe::transcribe(Path::new("recording.mp4"), api_key, &Options {
         format: Format::Srt,
         language: Some("zh".into()),

--- a/rust/src/cli/error.rs
+++ b/rust/src/cli/error.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error as AnyhowError};
+use anyhow::Error as AnyhowError;
 use serde::Serialize;
 use std::fmt;
 

--- a/rust/src/cli/error.rs
+++ b/rust/src/cli/error.rs
@@ -1,3 +1,4 @@
+use anyhow::{Error as AnyhowError};
 use serde::Serialize;
 use std::fmt;
 
@@ -46,8 +47,8 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl From<anyhow::Error> for Error {
-    fn from(error: anyhow::Error) -> Self {
+impl From<AnyhowError> for Error {
+    fn from(error: AnyhowError) -> Self {
         Self::new(
             "transcription_error",
             "",

--- a/rust/src/editor/.main.rs
+++ b/rust/src/editor/.main.rs
@@ -68,8 +68,12 @@ fn run_app(cx: &mut App) {
             let project_root = project_root.clone();
             let source_path = source_path.clone();
             let task = gpui_tokio::Tokio::spawn(cx, async move {
-                let srt = editor::transcription::start_transcription(source_path.clone(), project_root.clone(), api_key)
-                    .await?;
+                let srt = editor::transcription::start_transcription(
+                    source_path.clone(),
+                    project_root.clone(),
+                    api_key,
+                )
+                .await?;
                 log::info!("Writing SRT for {}", source_path.display());
                 let Some(stem) = source_path.file_stem() else {
                     bail!(

--- a/rust/src/editor/.main.rs
+++ b/rust/src/editor/.main.rs
@@ -13,6 +13,7 @@ mod playback_view;
 mod video;
 
 mod asset;
+use anyhow::{anyhow, bail};
 use asset::EditorAssets;
 
 use editor::global_settings::GlobalEditorSettings;
@@ -71,7 +72,7 @@ fn run_app(cx: &mut App) {
                     .await?;
                 log::info!("Writing SRT for {}", source_path.display());
                 let Some(stem) = source_path.file_stem() else {
-                    anyhow::bail!(
+                    bail!(
                         "transcription source has no filename at {}:{}",
                         file!(),
                         line!()
@@ -85,7 +86,7 @@ fn run_app(cx: &mut App) {
             cx.spawn(async move |_| {
                 let result = match task.await {
                     Ok(result) => result,
-                    Err(error) => Err(anyhow::anyhow!(
+                    Err(error) => Err(anyhow!(
                         "transcription task failed: {error} at {}:{}",
                         file!(),
                         line!()

--- a/rust/src/editor/.main.rs
+++ b/rust/src/editor/.main.rs
@@ -67,7 +67,7 @@ fn run_app(cx: &mut App) {
             let project_root = project_root.clone();
             let source_path = source_path.clone();
             let task = gpui_tokio::Tokio::spawn(cx, async move {
-                let srt = editor::transcription::start_transcription(source_path.clone(), api_key)
+                let srt = editor::transcription::start_transcription(source_path.clone(), project_root.clone(), api_key)
                     .await?;
                 log::info!("Writing SRT for {}", source_path.display());
                 let Some(stem) = source_path.file_stem() else {

--- a/rust/src/editor/clip_placement.rs
+++ b/rust/src/editor/clip_placement.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result};
 use super::*;
+use anyhow::Result;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ClipPlacementRejection {

--- a/rust/src/editor/clip_placement.rs
+++ b/rust/src/editor/clip_placement.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result};
 use super::*;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -46,7 +47,7 @@ pub(super) fn validate_clip_placement(
     clip_length: TimelineTime,
     target_timeline_start: TimelineTime,
     ignored_clip_ids: &HashSet<Ulid>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let expected_track_kind = if media_kind == MediaKind::Audio {
         TrackKind::Audio
     } else {
@@ -68,7 +69,7 @@ pub(super) fn validate_text_clip_placement(
     clip_length: TimelineTime,
     target_timeline_start: TimelineTime,
     ignored_clip_ids: &HashSet<Ulid>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     validate_clip_placement_on_track(
         timeline,
         target_track_id,
@@ -86,7 +87,7 @@ fn validate_clip_placement_on_track(
     clip_length: TimelineTime,
     target_timeline_start: TimelineTime,
     ignored_clip_ids: &HashSet<Ulid>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     if target_timeline_start < TimelineTime::ZERO {
         return Err(ClipPlacementRejection::BeforeTimelineStart.into());
     }

--- a/rust/src/editor/context_menu.rs
+++ b/rust/src/editor/context_menu.rs
@@ -50,7 +50,8 @@ impl Editor {
             !menu.is_directory && timeline_document::is_timeline_path(&menu.relative_path);
         let can_transcribe = !menu.is_directory
             && (explorer::is_video_path(&menu.relative_path)
-                || explorer::is_audio_path(&menu.relative_path));
+                || explorer::is_audio_path(&menu.relative_path)
+                || timeline_document::is_timeline_path(&menu.relative_path));
         let can_rename = !menu.relative_path.as_os_str().is_empty();
         let can_trash = can_rename
             && !self

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1015,6 +1015,7 @@ pub(super) fn edit_and_rebuild_timeline(
         &timeline.data,
         project_root,
         export::ExportOptions::from_timeline(&timeline.data),
+        false,
     )?;
 
     let previous_playhead = timeline.playhead();

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow, bail};
 use super::*;
 use gstreamer_editing_services::prelude::TimelineExt as _;
 use std::path::Path;
@@ -111,7 +112,7 @@ impl ClipClipboard {
         destination_path: &std::path::Path,
         destination: &TimelineSerialization,
         position: TimelineTime,
-    ) -> anyhow::Result<(Vec<Clip>, Vec<MediaAsset>)> {
+    ) -> Result<(Vec<Clip>, Vec<MediaAsset>)> {
         let mut clips = self.clips_at(position, destination.settings.frame_rate);
         let same_timeline = self.source_timeline == destination_path;
 
@@ -841,7 +842,7 @@ fn ripple_clips_after_deletion(
 pub(super) fn validate_clips_placements(
     timeline: &TimelineSerialization,
     clips: &[Clip],
-) -> anyhow::Result<()> {
+) -> Result<()> {
     if clips.is_empty() {
         return Err(ClipPlacementRejection::NoPlacements.into());
     }
@@ -996,7 +997,7 @@ pub(super) fn edit_and_rebuild_timeline(
     project_root: &Path,
     timeline: &mut TimelineRuntimeState,
     action: EditAction,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let action_type = action.kind();
     let t = Instant::now();
     let should_rebuild_timeline = edit_timeline(timeline, project_root, action)?;
@@ -1039,7 +1040,7 @@ pub(super) fn edit_timeline(
     timeline: &mut TimelineRuntimeState,
     project_root: &Path,
     action: EditAction,
-) -> anyhow::Result<bool> {
+) -> Result<bool> {
     match action {
         EditAction::AddClips { clips, assets } => {
             let mut updated_timeline = timeline.data.clone();
@@ -1049,7 +1050,7 @@ pub(super) fn edit_timeline(
             let ges = timeline.video_backend.ges_timeline();
             ges_add_clips(ges, &updated_timeline, project_root, &clips)?;
             if !ges.commit() {
-                anyhow::bail!("GStreamer could not commit the added clips.");
+                bail!("GStreamer could not commit the added clips.");
             }
             timeline.data = updated_timeline;
             return Ok(false);
@@ -1082,7 +1083,7 @@ pub(super) fn edit_timeline(
             ges_move_clips(ges, &updated_timeline, &ripple_placements)?;
             // Apply edits asynchronously while the preview pipeline is paused.
             if !ges.commit() {
-                anyhow::bail!(
+                bail!(
                     "GStreamer could not commit the removed clips at {}:{}",
                     file!(),
                     line!()
@@ -1106,7 +1107,7 @@ pub(super) fn edit_timeline(
             ges_remove_clips(ges, &removed_clips)?;
             ges_add_clips(ges, &updated_timeline, project_root, &added_clips)?;
             if !ges.commit() {
-                anyhow::bail!("GStreamer could not commit the split clips.");
+                bail!("GStreamer could not commit the split clips.");
             }
             timeline.data = updated_timeline;
             return Ok(false);
@@ -1124,7 +1125,7 @@ pub(super) fn edit_timeline(
             let ges = timeline.video_backend.ges_timeline();
             ges_move_clips(ges, &timeline.data, &placements)?;
             if !ges.commit() {
-                anyhow::bail!("GStreamer could not commit the moved clips.");
+                bail!("GStreamer could not commit the moved clips.");
             }
 
             for (clip_id, track_id, start) in placements {
@@ -1184,7 +1185,7 @@ pub(super) fn edit_timeline(
             )
             .expect("updated clip must be addable to GES");
             if !ges.commit() {
-                anyhow::bail!(
+                bail!(
                     "GStreamer could not commit the updated clip at {}:{}",
                     file!(),
                     line!()
@@ -1307,7 +1308,7 @@ fn ges_move_clips(
     ges: &gstreamer_editing_services::Timeline,
     timeline: &TimelineSerialization,
     placements: &[(Ulid, Ulid, TimelineTime)],
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     if placements.is_empty() {
@@ -1347,16 +1348,16 @@ fn ges_move_clips(
         let layer_index = ordered_tracks
             .iter()
             .position(|track| track.id == *track_id)
-            .ok_or_else(|| anyhow::anyhow!("Track {track_id} has no GES layer."))?;
+            .ok_or_else(|| anyhow!("Track {track_id} has no GES layer."))?;
         if layers.get(layer_index).is_none() {
-            return Err(anyhow::anyhow!("Track {track_id} has no GES layer."));
+            return Err(anyhow!("Track {track_id} has no GES layer."));
         }
         let clip_name = format!("opencut-clip-{clip_id}");
         let Some((original_layer_index, clip)) = clips_by_name.get(&clip_name) else {
             continue;
         };
         let Some(data) = timeline.clip(*clip_id) else {
-            anyhow::bail!("missing timeline clip {clip_id} at {}:{}", file!(), line!());
+            bail!("missing timeline clip {clip_id} at {}:{}", file!(), line!());
         };
         let (start, duration) =
             super::export_gstreamer::clip_clock_range(timeline.settings.frame_rate, data, *start);
@@ -1394,7 +1395,7 @@ fn ges_move_clips(
                 gstreamer_editing_services::Edge::None,
                 parking_start,
             )
-            .map_err(|error| anyhow::anyhow!("could not stage GES clip {clip_id}: {error}"))?;
+            .map_err(|error| anyhow!("could not stage GES clip {clip_id}: {error}"))?;
             parking_start = parking_start
                 .saturating_add(clip.duration().nseconds())
                 .saturating_add(parking_gap);
@@ -1408,9 +1409,9 @@ fn ges_move_clips(
             gstreamer_editing_services::Edge::None,
             start.nseconds(),
         )
-        .map_err(|error| anyhow::anyhow!("could not move GES clip {clip_id}: {error}"))?;
+        .map_err(|error| anyhow!("could not move GES clip {clip_id}: {error}"))?;
         if !clip.set_duration(*duration) {
-            anyhow::bail!(
+            bail!(
                 "could not set moved clip {clip_id} duration at {}:{}",
                 file!(),
                 line!()
@@ -1441,7 +1442,7 @@ fn ges_move_clips(
         .find(|clip| clip.name().as_deref() == Some("opencut-black-background"))
         && !background.set_duration(content_duration)
     {
-        anyhow::bail!("could not update the GES timeline background duration");
+        bail!("could not update the GES timeline background duration");
     }
     Ok(())
 }
@@ -1451,7 +1452,7 @@ fn ges_change_video_clip(
     timeline: &TimelineSerialization,
     clip_ids: &[Ulid],
     properties: VideoClipProperties,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     let options = export::ExportOptions::from_timeline(timeline);
@@ -1460,7 +1461,7 @@ fn ges_change_video_clip(
             continue;
         };
         let Some(asset) = timeline.asset(clip.asset_id) else {
-            anyhow::bail!(
+            bail!(
                 "clip {clip_id} has no source media at {}:{}",
                 file!(),
                 line!()
@@ -1473,7 +1474,7 @@ fn ges_change_video_clip(
             .flat_map(|layer| layer.clips())
             .find(|clip| clip.name().as_deref() == Some(name.as_str()))
         else {
-            anyhow::bail!("missing GES clip {clip_id} at {}:{}", file!(), line!());
+            bail!("missing GES clip {clip_id} at {}:{}", file!(), line!());
         };
         if let Err(error) = super::export_gstreamer::apply_video_transform(
             &rendered, timeline, asset, options, properties,
@@ -1494,7 +1495,7 @@ fn ges_change_text_clip(
     ges: &gstreamer_editing_services::Timeline,
     clip_id: Ulid,
     properties: &TextClipProperties,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     let clip_name = format!("opencut-clip-{clip_id}");
@@ -1503,11 +1504,11 @@ fn ges_change_text_clip(
         .into_iter()
         .flat_map(|layer| layer.clips())
         .find(|clip| clip.name().as_deref() == Some(clip_name.as_str()))
-        .ok_or_else(|| anyhow::anyhow!("timeline preview has no text clip for {clip_id}"))?;
+        .ok_or_else(|| anyhow!("timeline preview has no text clip for {clip_id}"))?;
     let overlay = clip
         .downcast::<gstreamer_editing_services::TitleClip>()
         .map_err(|_| {
-            anyhow::anyhow!(
+            anyhow!(
                 "timeline preview clip {clip_id} is not a text clip at {}:{}",
                 file!(),
                 line!()
@@ -1515,7 +1516,7 @@ fn ges_change_text_clip(
         })?;
     super::export_gstreamer::configure_text_clip(&overlay, properties, 1.0)?;
     if !ges.commit() {
-        anyhow::bail!("GStreamer could not commit the preview text change.");
+        bail!("GStreamer could not commit the preview text change.");
     }
     Ok(())
 }
@@ -1523,7 +1524,7 @@ fn ges_change_text_clip(
 fn ges_remove_clips(
     ges: &gstreamer_editing_services::Timeline,
     clips: &HashSet<Ulid>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     if clips.is_empty() {
@@ -1555,7 +1556,7 @@ fn ges_remove_clips(
             .unwrap_or_else(|| "<unnamed>".to_string());
         layer
             .remove_clip(&clip)
-            .map_err(|error| anyhow::anyhow!("could not remove GES clip {name}: {error}"))?;
+            .map_err(|error| anyhow!("could not remove GES clip {name}: {error}"))?;
     }
 
     let mut background = None;
@@ -1577,10 +1578,10 @@ fn ges_remove_clips(
         if content_duration_ns == 0 {
             background_layer
                 .remove_clip(&background)
-                .map_err(|error| anyhow::anyhow!("could not remove the GES background: {error}"))?;
+                .map_err(|error| anyhow!("could not remove the GES background: {error}"))?;
         } else if !background.set_duration(gstreamer::ClockTime::from_nseconds(content_duration_ns))
         {
-            anyhow::bail!("could not update the GES timeline background duration");
+            bail!("could not update the GES timeline background duration");
         }
     }
     Ok(())
@@ -1591,7 +1592,7 @@ fn ges_add_clips(
     timeline: &TimelineSerialization,
     project_root: &Path,
     clips: &[Clip],
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     let layers = ges.layers();
@@ -1617,14 +1618,14 @@ fn ges_add_clips(
     for clip in clips {
         let timeline_track = timeline
             .track(clip.track_id())
-            .ok_or_else(|| anyhow::anyhow!("Clip {} has no timeline track.", clip.id()))?;
+            .ok_or_else(|| anyhow!("Clip {} has no timeline track.", clip.id()))?;
         let layer_index = ordered_tracks
             .iter()
             .position(|track| track.id == timeline_track.id)
-            .ok_or_else(|| anyhow::anyhow!("Clip {} has no GES layer.", clip.id()))?;
+            .ok_or_else(|| anyhow!("Clip {} has no GES layer.", clip.id()))?;
         let layer = layers
             .get(layer_index)
-            .ok_or_else(|| anyhow::anyhow!("Clip {} has no GES layer.", clip.id()))?;
+            .ok_or_else(|| anyhow!("Clip {} has no GES layer.", clip.id()))?;
 
         if timeline_track.kind == TrackKind::Text {
             if !timeline_track.visible {
@@ -1632,9 +1633,9 @@ fn ges_add_clips(
             }
             let text = clip
                 .text()
-                .ok_or_else(|| anyhow::anyhow!("Media clip {} is on a text track.", clip.id()))?;
+                .ok_or_else(|| anyhow!("Media clip {} is on a text track.", clip.id()))?;
             let overlay = gstreamer_editing_services::TitleClip::new().ok_or_else(|| {
-                anyhow::anyhow!(
+                anyhow!(
                     "could not create text clip {} at {}:{}",
                     clip.id(),
                     file!(),
@@ -1644,7 +1645,7 @@ fn ges_add_clips(
             overlay
                 .set_name(Some(&format!("opencut-clip-{}", clip.id())))
                 .map_err(|error| {
-                    anyhow::anyhow!("could not identify clip {}: {error}", clip.id())
+                    anyhow!("could not identify clip {}: {error}", clip.id())
                 })?;
             let (start, duration) = super::export_gstreamer::clip_clock_range(
                 timeline.settings.frame_rate,
@@ -1652,7 +1653,7 @@ fn ges_add_clips(
                 clip.timeline_start(),
             );
             if !overlay.set_start(start) {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "could not set text clip {} start at {}:{}",
                     clip.id(),
                     file!(),
@@ -1660,7 +1661,7 @@ fn ges_add_clips(
                 ));
             }
             if !overlay.set_duration(duration) {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "could not set text clip {} duration at {}:{}",
                     clip.id(),
                     file!(),
@@ -1668,7 +1669,7 @@ fn ges_add_clips(
                 ));
             }
             layer.add_clip(&overlay).map_err(|error| {
-                anyhow::anyhow!(
+                anyhow!(
                     "could not add text clip {} to the GES timeline: {error}",
                     clip.id()
                 )
@@ -1679,10 +1680,10 @@ fn ges_add_clips(
 
         let media = clip
             .media()
-            .ok_or_else(|| anyhow::anyhow!("Text clip {} is on a media track.", clip.id()))?;
+            .ok_or_else(|| anyhow!("Text clip {} is on a media track.", clip.id()))?;
         let asset = timeline
             .asset(media.asset_id)
-            .ok_or_else(|| anyhow::anyhow!("Clip {} has no source media.", clip.id()))?;
+            .ok_or_else(|| anyhow!("Clip {} has no source media.", clip.id()))?;
         let mut track_types = gstreamer_editing_services::TrackType::empty();
         if timeline_track.kind == TrackKind::Video
             && timeline_track.visible
@@ -1708,11 +1709,11 @@ fn ges_add_clips(
         } else {
             let source = project_root.join(&asset.path);
             let uri = url::Url::from_file_path(&source).map_err(|_| {
-                anyhow::anyhow!("could not convert {} to a file URL", source.display())
+                anyhow!("could not convert {} to a file URL", source.display())
             })?;
             let uri_asset = gstreamer_editing_services::UriClipAsset::request_sync(uri.as_str())
                 .map_err(|error| {
-                    anyhow::anyhow!("could not inspect {}: {error}", source.display())
+                    anyhow!("could not inspect {}: {error}", source.display())
                 })?;
             uri_assets.insert(asset.id, uri_asset.clone());
             uri_asset
@@ -1732,11 +1733,11 @@ fn ges_add_clips(
         let ges_clip = layer
             .add_asset(&uri_asset, start, inpoint, duration, track_types)
             .map_err(|error| {
-                anyhow::anyhow!("could not add {} to the GES timeline: {error}", asset.name)
+                anyhow!("could not add {} to the GES timeline: {error}", asset.name)
             })?;
         ges_clip
             .set_name(Some(&format!("opencut-clip-{}", clip.id())))
-            .map_err(|error| anyhow::anyhow!("could not identify clip {}: {error}", clip.id()))?;
+            .map_err(|error| anyhow!("could not identify clip {}: {error}", clip.id()))?;
         if track_types.contains(gstreamer_editing_services::TrackType::VIDEO) {
             super::export_gstreamer::apply_video_transform(
                 &ges_clip,
@@ -1763,23 +1764,23 @@ fn ges_add_clips(
         .find(|clip| clip.name().as_deref() == Some("opencut-black-background"))
     {
         if !background.set_duration(content_duration) {
-            anyhow::bail!("could not update the GES timeline background duration");
+            bail!("could not update the GES timeline background duration");
         }
     } else if !content_duration.is_zero() {
         let background_layer = ges.append_layer();
         let background = gstreamer_editing_services::TestClip::new()
-            .ok_or_else(|| anyhow::anyhow!("could not create the GES timeline background"))?;
+            .ok_or_else(|| anyhow!("could not create the GES timeline background"))?;
         background.set_supported_formats(gstreamer_editing_services::TrackType::VIDEO);
         background.set_vpattern(gstreamer_editing_services::VideoTestPattern::Black);
         background.set_mute(true);
         background
             .set_name(Some("opencut-black-background"))
-            .map_err(|error| anyhow::anyhow!("could not identify the GES background: {error}"))?;
+            .map_err(|error| anyhow!("could not identify the GES background: {error}"))?;
         if !background.set_duration(content_duration) {
-            anyhow::bail!("could not set the GES timeline background duration");
+            bail!("could not set the GES timeline background duration");
         }
         background_layer.add_clip(&background).map_err(|error| {
-            anyhow::anyhow!("could not add the GES timeline background: {error}")
+            anyhow!("could not add the GES timeline background: {error}")
         })?;
     }
     Ok(())
@@ -1789,7 +1790,7 @@ fn ges_add_clips(
 pub(super) fn data_parity_check(
     timeline_runtime: &TimelineRuntimeState,
     ges_timeline: &gstreamer_editing_services::Timeline,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     use gstreamer_editing_services::prelude::*;
 
     let timeline = &timeline_runtime.data;
@@ -1810,7 +1811,7 @@ pub(super) fn data_parity_check(
     for (layer_index, layer) in layers.iter().enumerate() {
         for clip in layer.clips() {
             let Some(name) = clip.name() else {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "GES layer {layer_index} contains an unnamed clip"
                 ));
             };
@@ -1819,15 +1820,15 @@ pub(super) fn data_parity_check(
                 continue;
             }
             let Some(id) = name.strip_prefix("opencut-clip-") else {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "GES layer {layer_index} contains unexpected clip `{name}`"
                 ));
             };
             let id = id
                 .parse::<Ulid>()
-                .map_err(|error| anyhow::anyhow!("GES clip `{name}` has an invalid ID: {error}"))?;
+                .map_err(|error| anyhow!("GES clip `{name}` has an invalid ID: {error}"))?;
             if ges_clips.insert(id, (layer_index, clip)).is_some() {
-                return Err(anyhow::anyhow!("GES contains duplicate clip {id}"));
+                return Err(anyhow!("GES contains duplicate clip {id}"));
             }
         }
     }
@@ -1843,15 +1844,15 @@ pub(super) fn data_parity_check(
         let clip_id = clip.id();
         let track = timeline
             .track(clip.track_id())
-            .ok_or_else(|| anyhow::anyhow!("Timeline clip {clip_id} has no track"))?;
+            .ok_or_else(|| anyhow!("Timeline clip {clip_id} has no track"))?;
         let expected_layer = ordered_tracks
             .iter()
             .position(|candidate| candidate.id == track.id)
             .ok_or_else(|| {
-                anyhow::anyhow!("Timeline track {} has no GES layer mapping", track.id)
+                anyhow!("Timeline track {} has no GES layer mapping", track.id)
             })?;
         if layers.get(expected_layer).is_none() {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Timeline track {} expects missing GES layer {expected_layer}",
                 track.id
             ));
@@ -1866,7 +1867,7 @@ pub(super) fn data_parity_check(
             Clip::Video(media) | Clip::Audio(media) => {
                 let asset = timeline
                     .asset(media.asset_id)
-                    .ok_or_else(|| anyhow::anyhow!("Timeline clip {clip_id} has no media asset"))?;
+                    .ok_or_else(|| anyhow!("Timeline clip {clip_id} has no media asset"))?;
                 let mut formats = gstreamer_editing_services::TrackType::empty();
                 if track.kind == TrackKind::Video
                     && track.visible
@@ -1897,23 +1898,23 @@ pub(super) fn data_parity_check(
         let rendered = ges_clips.remove(&clip_id);
         if !expected_rendered {
             if rendered.is_some() {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "Timeline clip {clip_id} should not be rendered, but GES contains it"
                 ));
             }
             continue;
         }
         let Some((actual_layer, rendered)) = rendered else {
-            return Err(anyhow::anyhow!("GES is missing timeline clip {clip_id}"));
+            return Err(anyhow!("GES is missing timeline clip {clip_id}"));
         };
         if actual_layer != expected_layer {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} is on GES layer {actual_layer}, expected {expected_layer}"
             ));
         }
         let expected_start = clock_time(timeline.duration(clip.timeline_start()));
         if clock_time_frame(rendered.start()) != clip.timeline_start() {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} starts at {} ns (frame {}) in GES, expected {} ns (frame {})",
                 rendered.start().nseconds(),
                 clock_time_frame(rendered.start()).frames(),
@@ -1924,7 +1925,7 @@ pub(super) fn data_parity_check(
         let expected_duration_frames = clip.frame_length(frame_rate);
         let expected_duration = clock_time(timeline.duration(expected_duration_frames));
         if clock_time_frame(rendered.duration()) != expected_duration_frames {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} lasts {} ns ({} frames) in GES, expected {} ns ({} frames)",
                 rendered.duration().nseconds(),
                 clock_time_frame(rendered.duration()).frames(),
@@ -1933,7 +1934,7 @@ pub(super) fn data_parity_check(
             ));
         }
         if clock_time_frame(rendered.inpoint()) != clock_time_frame(expected_inpoint) {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} has in-point {} ns (frame {}) in GES, expected {} ns (frame {})",
                 rendered.inpoint().nseconds(),
                 clock_time_frame(rendered.inpoint()).frames(),
@@ -1943,7 +1944,7 @@ pub(super) fn data_parity_check(
         }
         if matches!(clip, Clip::Text(_)) && !rendered.is::<gstreamer_editing_services::TitleClip>()
         {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} is not a GES title at {}:{}",
                 file!(),
                 line!()
@@ -1952,7 +1953,7 @@ pub(super) fn data_parity_check(
         if let Some(expected_formats) = expected_formats
             && rendered.supported_formats() != expected_formats
         {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Clip {clip_id} has GES formats {:?}, expected {:?}",
                 rendered.supported_formats(),
                 expected_formats
@@ -1961,17 +1962,17 @@ pub(super) fn data_parity_check(
     }
 
     if let Some((clip_id, _)) = ges_clips.into_iter().next() {
-        return Err(anyhow::anyhow!("GES contains unexpected clip {clip_id}"));
+        return Err(anyhow!("GES contains unexpected clip {clip_id}"));
     }
     let expected_background_duration = clock_time(timeline.duration(timeline.content_duration()));
     match backgrounds.as_slice() {
         [] if expected_background_duration.is_zero() => {}
-        [] => return Err(anyhow::anyhow!("GES is missing the black background clip")),
+        [] => return Err(anyhow!("GES is missing the black background clip")),
         [_] if expected_background_duration.is_zero() => {
-            anyhow::bail!("GES contains a black background for an empty timeline");
+            bail!("GES contains a black background for an empty timeline");
         }
         [background] if background.start() != gstreamer::ClockTime::ZERO => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "GES background starts at {} ns, expected 0 ns",
                 background.start().nseconds()
             ));
@@ -1980,7 +1981,7 @@ pub(super) fn data_parity_check(
             if clock_time_frame(background.duration())
                 != clock_time_frame(expected_background_duration) =>
         {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "GES background lasts {} ns ({} frames), expected {} ns ({} frames)",
                 background.duration().nseconds(),
                 clock_time_frame(background.duration()).frames(),
@@ -1990,7 +1991,7 @@ pub(super) fn data_parity_check(
         }
         [_] => {}
         _ => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "GES contains multiple black background clips"
             ));
         }

--- a/rust/src/editor/editing.rs
+++ b/rust/src/editor/editing.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, anyhow, bail};
 use super::*;
+use anyhow::{Result, anyhow, bail};
 use gstreamer_editing_services::prelude::TimelineExt as _;
 use std::path::Path;
 
@@ -1644,9 +1644,7 @@ fn ges_add_clips(
             })?;
             overlay
                 .set_name(Some(&format!("opencut-clip-{}", clip.id())))
-                .map_err(|error| {
-                    anyhow!("could not identify clip {}: {error}", clip.id())
-                })?;
+                .map_err(|error| anyhow!("could not identify clip {}: {error}", clip.id()))?;
             let (start, duration) = super::export_gstreamer::clip_clock_range(
                 timeline.settings.frame_rate,
                 clip,
@@ -1708,13 +1706,10 @@ fn ges_add_clips(
             uri_asset.clone()
         } else {
             let source = project_root.join(&asset.path);
-            let uri = url::Url::from_file_path(&source).map_err(|_| {
-                anyhow!("could not convert {} to a file URL", source.display())
-            })?;
+            let uri = url::Url::from_file_path(&source)
+                .map_err(|_| anyhow!("could not convert {} to a file URL", source.display()))?;
             let uri_asset = gstreamer_editing_services::UriClipAsset::request_sync(uri.as_str())
-                .map_err(|error| {
-                    anyhow!("could not inspect {}: {error}", source.display())
-                })?;
+                .map_err(|error| anyhow!("could not inspect {}: {error}", source.display()))?;
             uri_assets.insert(asset.id, uri_asset.clone());
             uri_asset
         };
@@ -1779,9 +1774,9 @@ fn ges_add_clips(
         if !background.set_duration(content_duration) {
             bail!("could not set the GES timeline background duration");
         }
-        background_layer.add_clip(&background).map_err(|error| {
-            anyhow!("could not add the GES timeline background: {error}")
-        })?;
+        background_layer
+            .add_clip(&background)
+            .map_err(|error| anyhow!("could not add the GES timeline background: {error}"))?;
     }
     Ok(())
 }
@@ -1811,9 +1806,7 @@ pub(super) fn data_parity_check(
     for (layer_index, layer) in layers.iter().enumerate() {
         for clip in layer.clips() {
             let Some(name) = clip.name() else {
-                return Err(anyhow!(
-                    "GES layer {layer_index} contains an unnamed clip"
-                ));
+                return Err(anyhow!("GES layer {layer_index} contains an unnamed clip"));
             };
             if name.as_str() == "opencut-black-background" {
                 backgrounds.push(clip);
@@ -1848,9 +1841,7 @@ pub(super) fn data_parity_check(
         let expected_layer = ordered_tracks
             .iter()
             .position(|candidate| candidate.id == track.id)
-            .ok_or_else(|| {
-                anyhow!("Timeline track {} has no GES layer mapping", track.id)
-            })?;
+            .ok_or_else(|| anyhow!("Timeline track {} has no GES layer mapping", track.id))?;
         if layers.get(expected_layer).is_none() {
             return Err(anyhow!(
                 "Timeline track {} expects missing GES layer {expected_layer}",
@@ -1991,9 +1982,7 @@ pub(super) fn data_parity_check(
         }
         [_] => {}
         _ => {
-            return Err(anyhow!(
-                "GES contains multiple black background clips"
-            ));
+            return Err(anyhow!("GES contains multiple black background clips"));
         }
     }
 

--- a/rust/src/editor/editor.rs
+++ b/rust/src/editor/editor.rs
@@ -51,6 +51,7 @@ impl Editor {
                     &timeline_data,
                     &project_root,
                     export::ExportOptions::from_timeline(&timeline_data),
+                    false,
                 )
                 .with_context(|| format!("build_ges_timeline failed at {}:{}", file!(), line!()))?;
                 let timeline =

--- a/rust/src/editor/editor.rs
+++ b/rust/src/editor/editor.rs
@@ -1,3 +1,4 @@
+use anyhow::{Error};
 use crate::editor::{explorer::ExplorerState, project_settings::ProjectLocalSettings};
 
 use super::srt::srt_text_clips;
@@ -270,7 +271,7 @@ fn handle_app_event(
                         timeline.interaction.selected_clip_id = selected_clip_id;
                         timeline.save(&project_root);
                         editor.status = Some("Added subtitles to the timeline.".to_string());
-                        Ok::<(), anyhow::Error>(())
+                        Ok::<(), Error>(())
                     })();
                     if let Err(error) = result {
                         editor.status = Some(format!("Could not add subtitles: {error}"));
@@ -327,7 +328,7 @@ fn start_updates(cx: &mut Context<Editor>) {
                 if should_render {
                     cx.notify();
                 }
-                Ok::<(), anyhow::Error>(())
+                Ok::<(), Error>(())
             });
             match result {
                 Ok(Ok(())) => {}

--- a/rust/src/editor/editor.rs
+++ b/rust/src/editor/editor.rs
@@ -1,5 +1,5 @@
-use anyhow::{Error};
 use crate::editor::{explorer::ExplorerState, project_settings::ProjectLocalSettings};
+use anyhow::Error;
 
 use super::srt::srt_text_clips;
 use super::*;

--- a/rust/src/editor/explorer.rs
+++ b/rust/src/editor/explorer.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow, bail};
 use crate::{
     editor::{
         ACCENT, BORDER, MUTED, OpenInDefaultApp, PANEL, RevealInFinder, SURFACE, SURFACE_HOVER,
@@ -111,7 +112,7 @@ impl Default for ExplorerExpansion {
 }
 
 impl ExplorerState {
-    pub(super) fn refresh_file_tree(&mut self, project_root: &Path) -> anyhow::Result<()> {
+    pub(super) fn refresh_file_tree(&mut self, project_root: &Path) -> Result<()> {
         self.last_tree_scan = Instant::now();
         self.file_tree = visible_tree(project_root, &self.expanded_directories)?;
         Ok(())
@@ -121,7 +122,7 @@ impl ExplorerState {
         &mut self,
         project_root: &Path,
         relative_path: PathBuf,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         if !self.expanded_directories.remove(&relative_path) {
             self.expanded_directories.insert(relative_path);
         }
@@ -130,7 +131,7 @@ impl ExplorerState {
 }
 
 impl Editor {
-    pub(super) fn save_explorer_expansion(&self) -> anyhow::Result<()> {
+    pub(super) fn save_explorer_expansion(&self) -> Result<()> {
         save_explorer_expansion(
             &self.project_root,
             &self.explorer.expanded_directories,
@@ -370,7 +371,7 @@ impl Editor {
         raw_start: TimelineTime,
         mut asset: MediaAsset,
         cx: &mut Context<Self>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         let Some(timeline) = self.timeline.as_ref() else {
             return Ok(());
         };
@@ -426,7 +427,7 @@ impl Editor {
         let media_clip = match track_kind {
             Some(TrackKind::Video) => Clip::Video(media_clip),
             Some(TrackKind::Audio) => Clip::Audio(media_clip),
-            _ => anyhow::bail!("the drop target is not a media track"),
+            _ => bail!("the drop target is not a media track"),
         };
 
         edit_and_rebuild_timeline(
@@ -499,21 +500,21 @@ fn remap_relative_path(
 }
 
 #[cfg(target_os = "macos")]
-fn move_path_to_trash(path: &std::path::Path) -> anyhow::Result<()> {
+fn move_path_to_trash(path: &std::path::Path) -> Result<()> {
     use objc2_foundation::{NSFileManager, NSString, NSURL};
 
     let path = path
         .to_str()
-        .ok_or_else(|| anyhow::anyhow!("the path is not valid UTF-8"))?;
+        .ok_or_else(|| anyhow!("the path is not valid UTF-8"))?;
     let url = NSURL::fileURLWithPath(&NSString::from_str(path));
     NSFileManager::defaultManager()
         .trashItemAtURL_resultingItemURL_error(&url, None)
-        .map_err(|error| anyhow::anyhow!("{error}"))
+        .map_err(|error| anyhow!("{error}"))
 }
 
 #[cfg(not(target_os = "macos"))]
-fn move_path_to_trash(_path: &std::path::Path) -> anyhow::Result<()> {
-    Err(anyhow::anyhow!(
+fn move_path_to_trash(_path: &std::path::Path) -> Result<()> {
+    Err(anyhow!(
         "moving files to the system Trash is not supported on this platform"
     ))
 }
@@ -561,22 +562,22 @@ fn save_explorer_expansion(
     project_root: &Path,
     expanded_directories: &HashSet<PathBuf>,
     root_expanded: bool,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let path = file_explorer_settings_path(project_root);
     let Some(directory) = path.parent() else {
-        anyhow::bail!("file explorer settings path had no parent directory");
+        bail!("file explorer settings path had no parent directory");
     };
     fs::create_dir_all(directory)
-        .map_err(|error| anyhow::anyhow!("could not create {}: {error}", directory.display()))?;
+        .map_err(|error| anyhow!("could not create {}: {error}", directory.display()))?;
     let mut expanded_directories = expanded_directories.iter().cloned().collect::<Vec<_>>();
     expanded_directories.sort();
     let json = serde_json::to_string_pretty(&FileExplorerSettings {
         expanded_directories,
         root_expanded,
     })
-    .map_err(|error| anyhow::anyhow!("could not serialize file explorer settings: {error}"))?;
+    .map_err(|error| anyhow!("could not serialize file explorer settings: {error}"))?;
     fs::write(&path, format!("{json}\n"))
-        .map_err(|error| anyhow::anyhow!("could not write {}: {error}", path.display()))
+        .map_err(|error| anyhow!("could not write {}: {error}", path.display()))
 }
 
 fn file_explorer_settings_path(project_root: &Path) -> PathBuf {

--- a/rust/src/editor/explorer.rs
+++ b/rust/src/editor/explorer.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow, bail};
 use crate::{
     editor::{
         ACCENT, BORDER, MUTED, OpenInDefaultApp, PANEL, RevealInFinder, SURFACE, SURFACE_HOVER,
@@ -18,6 +17,7 @@ use crate::{
     },
     video::FileVideoBackend,
 };
+use anyhow::{Result, anyhow, bail};
 use gpui::{
     AppContext as _, Context, CursorStyle, Entity, InteractiveElement, IntoElement, MouseButton,
     MouseDownEvent, ParentElement, StatefulInteractiveElement, Styled, Window, div, px, rgb,
@@ -118,11 +118,7 @@ impl ExplorerState {
         Ok(())
     }
 
-    fn toggle_directory(
-        &mut self,
-        project_root: &Path,
-        relative_path: PathBuf,
-    ) -> Result<()> {
+    fn toggle_directory(&mut self, project_root: &Path, relative_path: PathBuf) -> Result<()> {
         if !self.expanded_directories.remove(&relative_path) {
             self.expanded_directories.insert(relative_path);
         }

--- a/rust/src/editor/explorer_drag.rs
+++ b/rust/src/editor/explorer_drag.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result};
+use anyhow::Result;
 use std::{fs::read_to_string, path::PathBuf};
 
 use gpui::{

--- a/rust/src/editor/explorer_drag.rs
+++ b/rust/src/editor/explorer_drag.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result};
 use std::{fs::read_to_string, path::PathBuf};
 
 use gpui::{
@@ -32,7 +33,7 @@ pub enum AssetBeingDragged {
 }
 
 impl AssetBeingDragged {
-    pub fn from_file_entry(entry: &FileTreeEntry) -> anyhow::Result<Self> {
+    pub fn from_file_entry(entry: &FileTreeEntry) -> Result<Self> {
         let x = match entry.kind {
             FileTreeEntryKind::Video | FileTreeEntryKind::Image | FileTreeEntryKind::Audio => {
                 let metadata = probe_asset(&entry.absolute_path)?;

--- a/rust/src/editor/explorer_file_entry.rs
+++ b/rust/src/editor/explorer_file_entry.rs
@@ -1,7 +1,7 @@
+use anyhow::{Context as _, Result, anyhow};
 use crate::editor::{AppEvent, explorer_drag::AssetBeingDragged};
 
 use super::*;
-use anyhow::Context as _;
 use std::{collections::HashSet, fs, path::Path};
 use url::Url;
 
@@ -222,7 +222,7 @@ pub enum FileTreeEntryKind {
 pub fn visible_tree(
     project_root: &Path,
     expanded_directories: &HashSet<PathBuf>,
-) -> anyhow::Result<Vec<FileTreeEntry>> {
+) -> Result<Vec<FileTreeEntry>> {
     let mut entries = Vec::new();
     read_directory(
         project_root,
@@ -236,7 +236,7 @@ pub fn visible_tree(
 
 /// Searches the complete project tree, independently of which folders are expanded.
 /// Matching ancestor directories are included so results retain their hierarchy.
-pub fn search_tree(project_root: &Path, query: &str) -> anyhow::Result<Vec<FileTreeEntry>> {
+pub fn search_tree(project_root: &Path, query: &str) -> Result<Vec<FileTreeEntry>> {
     let query = query.trim().to_lowercase();
     if query.is_empty() {
         return Ok(Vec::new());
@@ -251,7 +251,7 @@ fn search_directory(
     depth: usize,
     query: &str,
     is_root: bool,
-) -> anyhow::Result<Vec<FileTreeEntry>> {
+) -> Result<Vec<FileTreeEntry>> {
     let directory = project_root.join(relative_directory);
     let children = match directory_children(&directory) {
         Ok(children) => children,
@@ -310,7 +310,7 @@ fn read_directory(
     depth: usize,
     expanded_directories: &HashSet<PathBuf>,
     entries: &mut Vec<FileTreeEntry>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let directory = project_root.join(relative_directory);
     let children = directory_children(&directory)?;
 
@@ -339,9 +339,9 @@ fn read_directory(
     Ok(())
 }
 
-fn directory_children(directory: &Path) -> anyhow::Result<Vec<(String, bool, Option<u64>)>> {
+fn directory_children(directory: &Path) -> Result<Vec<(String, bool, Option<u64>)>> {
     let mut children = fs::read_dir(directory)
-        .map_err(|error| anyhow::anyhow!("could not read {}: {error}", directory.display()))?
+        .map_err(|error| anyhow!("could not read {}: {error}", directory.display()))?
         .filter_map(Result::ok)
         .filter_map(|entry| {
             let file_type = entry.file_type().ok()?;

--- a/rust/src/editor/explorer_file_entry.rs
+++ b/rust/src/editor/explorer_file_entry.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context as _, Result, anyhow};
 use crate::editor::{AppEvent, explorer_drag::AssetBeingDragged};
+use anyhow::{Context as _, Result, anyhow};
 
 use super::*;
 use std::{collections::HashSet, fs, path::Path};

--- a/rust/src/editor/explorer_file_menu.rs
+++ b/rust/src/editor/explorer_file_menu.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, anyhow, bail};
 use super::*;
+use anyhow::{Result, anyhow, bail};
 
 impl Editor {
     /// Opens the new-timeline dialog for `relative_directory`, pre-filled with the next
@@ -95,9 +95,8 @@ impl Editor {
                 new_relative.display()
             ));
         }
-        std::fs::rename(&old_path, &new_path).map_err(|error| {
-            anyhow!("Could not rename {}: {error}", old_relative.display())
-        })?;
+        std::fs::rename(&old_path, &new_path)
+            .map_err(|error| anyhow!("Could not rename {}: {error}", old_relative.display()))?;
 
         if let Some(timeline) = self.timeline.as_mut() {
             let paths = timeline
@@ -217,10 +216,7 @@ impl Editor {
         cx.open_with_system(&path);
     }
 
-    pub(in crate::editor) fn trash_selected_file(
-        &mut self,
-        cx: &mut Context<Self>,
-    ) -> Result<()> {
+    pub(in crate::editor) fn trash_selected_file(&mut self, cx: &mut Context<Self>) -> Result<()> {
         let ContextMenu::File(menu) = &self.context_menu else {
             return Ok(());
         };
@@ -246,9 +242,7 @@ impl Editor {
             .unwrap_or_else(|| relative_path.display().to_string());
         if let Err(error) = move_path_to_trash(&path) {
             self.status = None;
-            return Err(anyhow!(
-                "Could not move {display_name} to Trash: {error}"
-            ));
+            return Err(anyhow!("Could not move {display_name} to Trash: {error}"));
         }
         self.explorer
             .expanded_directories

--- a/rust/src/editor/explorer_file_menu.rs
+++ b/rust/src/editor/explorer_file_menu.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow, bail};
 use super::*;
 
 impl Editor {
@@ -29,7 +30,7 @@ impl Editor {
         cx.notify();
     }
 
-    pub(crate) fn finish_create_timeline(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
+    pub(crate) fn finish_create_timeline(&mut self, cx: &mut Context<Self>) -> Result<()> {
         let Some(state) = self.explorer.new_timeline_dialog.as_ref() else {
             return Ok(());
         };
@@ -37,7 +38,7 @@ impl Editor {
         let name = state.input.read(cx).query().trim().to_string();
         let (relative_path, timeline) =
             timeline_document::create(&self.project_root, &relative_directory, &name)
-                .map_err(|error| anyhow::anyhow!("Could not create timeline: {error}"))?;
+                .map_err(|error| anyhow!("Could not create timeline: {error}"))?;
         self.explorer.new_timeline_dialog = None;
         self.activate_created_timeline(relative_directory, relative_path, timeline, cx)
     }
@@ -72,14 +73,14 @@ impl Editor {
         cx.notify();
     }
 
-    pub(crate) fn finish_rename(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
+    pub(crate) fn finish_rename(&mut self, cx: &mut Context<Self>) -> Result<()> {
         let Some(state) = self.explorer.rename_dialog.as_ref() else {
             return Ok(());
         };
         let old_relative = state.relative_path.clone();
         let new_name = state.input.read(cx).query().trim().to_string();
         let Some(new_relative) = renamed_relative_path(&old_relative, &new_name) else {
-            anyhow::bail!("Enter a single non-empty file or folder name.");
+            bail!("Enter a single non-empty file or folder name.");
         };
         if new_relative == old_relative {
             self.explorer.rename_dialog = None;
@@ -89,13 +90,13 @@ impl Editor {
         let old_path = self.project_root.join(&old_relative);
         let new_path = self.project_root.join(&new_relative);
         if new_path.exists() {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Cannot rename: {} already exists.",
                 new_relative.display()
             ));
         }
         std::fs::rename(&old_path, &new_path).map_err(|error| {
-            anyhow::anyhow!("Could not rename {}: {error}", old_relative.display())
+            anyhow!("Could not rename {}: {error}", old_relative.display())
         })?;
 
         if let Some(timeline) = self.timeline.as_mut() {
@@ -219,7 +220,7 @@ impl Editor {
     pub(in crate::editor) fn trash_selected_file(
         &mut self,
         cx: &mut Context<Self>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         let ContextMenu::File(menu) = &self.context_menu else {
             return Ok(());
         };
@@ -228,14 +229,14 @@ impl Editor {
 
         // The project root is the workspace itself, not an entry within it.
         if relative_path.as_os_str().is_empty() {
-            anyhow::bail!("The project folder cannot be moved to Trash here.");
+            bail!("The project folder cannot be moved to Trash here.");
         }
         if self
             .timeline
             .as_ref()
             .is_some_and(|timeline| timeline.path.starts_with(&relative_path))
         {
-            anyhow::bail!("The active timeline cannot be moved to Trash.");
+            bail!("The active timeline cannot be moved to Trash.");
         }
 
         let path = self.project_root.join(&relative_path);
@@ -245,7 +246,7 @@ impl Editor {
             .unwrap_or_else(|| relative_path.display().to_string());
         if let Err(error) = move_path_to_trash(&path) {
             self.status = None;
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Could not move {display_name} to Trash: {error}"
             ));
         }

--- a/rust/src/editor/export.rs
+++ b/rust/src/editor/export.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result};
 use super::timeline::{FrameRate, TimelineSerialization};
 use std::path::Path;
 
@@ -60,7 +61,7 @@ pub(super) fn export_timeline(
     output: &Path,
     options: ExportOptions,
     report_progress: impl FnMut(f32),
-) -> anyhow::Result<()> {
+) -> Result<()> {
     super::export_gstreamer::export_timeline(
         timeline,
         project_root,

--- a/rust/src/editor/export.rs
+++ b/rust/src/editor/export.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result};
 use super::timeline::{FrameRate, TimelineSerialization};
+use anyhow::Result;
 use std::path::Path;
 
 pub(super) const DEFAULT_VIDEO_BIT_RATE: usize = 8_000_000;

--- a/rust/src/editor/export_dialog.rs
+++ b/rust/src/editor/export_dialog.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow, bail};
 use super::export::{DEFAULT_VIDEO_BIT_RATE, ExportEncoder, ExportOptions, export_timeline};
 use super::*;
 use std::{
@@ -51,7 +52,7 @@ fn validated_export(
     state: &ExportDialogState,
     project_root: &Path,
     cx: &App,
-) -> anyhow::Result<ValidatedExport> {
+) -> Result<ValidatedExport> {
     let video_bit_rate = parse_bitrate(state.bitrate.read(cx).query())?;
     let destination = parse_destination(state.destination.read(cx).query(), project_root)?;
 
@@ -886,22 +887,22 @@ fn export_dialog_button(
         .child(label)
 }
 
-fn parse_bitrate(value: &str) -> anyhow::Result<usize> {
+fn parse_bitrate(value: &str) -> Result<usize> {
     let megabits = value
         .trim()
         .parse::<usize>()
-        .map_err(|_| anyhow::anyhow!("Bitrate must be a whole number in Mb/s."))?;
+        .map_err(|_| anyhow!("Bitrate must be a whole number in Mb/s."))?;
     if !(1..=200).contains(&megabits) {
-        anyhow::bail!("Bitrate must be between 1 and 200 Mb/s.");
+        bail!("Bitrate must be between 1 and 200 Mb/s.");
     }
     megabits
         .checked_mul(1_000_000)
-        .ok_or_else(|| anyhow::anyhow!("Bitrate is too large."))
+        .ok_or_else(|| anyhow!("Bitrate is too large."))
 }
 
-fn parse_destination(value: &str, project_root: &Path) -> anyhow::Result<PathBuf> {
+fn parse_destination(value: &str, project_root: &Path) -> Result<PathBuf> {
     if value.trim().is_empty() {
-        anyhow::bail!("Choose an export destination.");
+        bail!("Choose an export destination.");
     }
     let mut path = expand_home(value.trim());
     if path.is_relative() {
@@ -909,10 +910,10 @@ fn parse_destination(value: &str, project_root: &Path) -> anyhow::Result<PathBuf
     }
     path = with_mp4_extension(path);
     let Some(parent) = path.parent() else {
-        anyhow::bail!("Export destination has no parent folder.");
+        bail!("Export destination has no parent folder.");
     };
     if !parent.is_dir() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "Destination folder does not exist: {}",
             parent.display()
         ));

--- a/rust/src/editor/export_dialog.rs
+++ b/rust/src/editor/export_dialog.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, anyhow, bail};
 use super::export::{DEFAULT_VIDEO_BIT_RATE, ExportEncoder, ExportOptions, export_timeline};
 use super::*;
+use anyhow::{Result, anyhow, bail};
 use std::{
     env,
     path::{Path, PathBuf},

--- a/rust/src/editor/export_gstreamer.rs
+++ b/rust/src/editor/export_gstreamer.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow, bail};
 use super::{
     clip_render_plan::{resolve_audio_clip_render_plan, resolve_visual_clip_render_plan},
     export::{ExportEncoder, ExportOptions},
@@ -7,6 +6,7 @@ use super::{
     timeline_clip::{Clip, TextClipProperties, VideoClipProperties},
     track::{Track, TrackKind},
 };
+use anyhow::{Result, anyhow, bail};
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_editing_services as ges;
@@ -28,9 +28,8 @@ pub(super) fn export_timeline(
     if timeline.clips.is_empty() {
         bail!("Add at least one clip before exporting.");
     }
-    ges::init().map_err(|error| {
-        anyhow!("could not initialize GStreamer Editing Services: {error}")
-    })?;
+    ges::init()
+        .map_err(|error| anyhow!("could not initialize GStreamer Editing Services: {error}"))?;
     report_progress(0.0);
 
     let temporary_output = TemporaryOutput::new(temporary_output_path(output))?;
@@ -178,9 +177,9 @@ pub fn build_ges_timeline(
                 .collect::<Vec<_>>();
             clips.sort_by_key(|clip| clip.timeline_start());
             for clip in clips {
-                let text = clip.text().ok_or_else(|| {
-                    anyhow!("Media clip {} is on a text track.", clip.id())
-                })?;
+                let text = clip
+                    .text()
+                    .ok_or_else(|| anyhow!("Media clip {} is on a text track.", clip.id()))?;
                 let overlay = ges::TitleClip::new().ok_or_else(|| {
                     anyhow!(
                         "could not create text clip {} at {}:{}",
@@ -191,9 +190,7 @@ pub fn build_ges_timeline(
                 })?;
                 overlay
                     .set_name(Some(&format!("opencut-clip-{}", clip.id())))
-                    .map_err(|error| {
-                        anyhow!("could not identify clip {}: {error}", clip.id())
-                    })?;
+                    .map_err(|error| anyhow!("could not identify clip {}: {error}", clip.id()))?;
                 let (start, duration) = clip_clock_range(
                     timeline_data.settings.frame_rate,
                     clip,
@@ -248,9 +245,8 @@ pub fn build_ges_timeline(
                 asset.clone()
             } else {
                 let source = project_root.join(&asset.path);
-                let uri = Url::from_file_path(&source).map_err(|_| {
-                    anyhow!("could not convert {} to a file URL", source.display())
-                })?;
+                let uri = Url::from_file_path(&source)
+                    .map_err(|_| anyhow!("could not convert {} to a file URL", source.display()))?;
                 let uri_asset = ges::UriClipAsset::request_sync(uri.as_str()).map_err(|error| {
                     anyhow!(
                         "build_ges_timeline failed: could not inspect {}: {error}",
@@ -277,9 +273,7 @@ pub fn build_ges_timeline(
                 })?;
             ges_clip
                 .set_name(Some(&format!("opencut-clip-{}", clip.id())))
-                .map_err(|error| {
-                    anyhow!("could not identify clip {}: {error}", clip.id())
-                })?;
+                .map_err(|error| anyhow!("could not identify clip {}: {error}", clip.id()))?;
             if track_types.contains(ges::TrackType::VIDEO) {
                 apply_video_transform(
                     &ges_clip,
@@ -314,9 +308,7 @@ pub fn build_ges_timeline(
         background.set_mute(true);
         background
             .set_name(Some("opencut-black-background"))
-            .map_err(|error| {
-                anyhow!("could not identify the timeline background: {error}")
-            })?;
+            .map_err(|error| anyhow!("could not identify the timeline background: {error}"))?;
         if !background.set_duration(frame_clock_time(
             timeline_data.settings.frame_rate,
             timeline_data.content_duration(),

--- a/rust/src/editor/export_gstreamer.rs
+++ b/rust/src/editor/export_gstreamer.rs
@@ -117,12 +117,19 @@ pub fn configure_text_clip(
     Ok(())
 }
 
-pub(super) fn build_ges_timeline(
+pub fn build_ges_timeline(
     timeline_data: &TimelineSerialization,
     project_root: &Path,
     options: ExportOptions,
+    audio_only: bool,
 ) -> anyhow::Result<ges::Timeline> {
-    let timeline = ges::Timeline::new_audio_video();
+    let timeline = if audio_only {
+        let timeline = ges::Timeline::new();
+        timeline.add_track(&ges::AudioTrack::new())?;
+        timeline
+    } else {
+        ges::Timeline::new_audio_video()
+    };
     let video_caps = gst::Caps::builder("video/x-raw")
         .field("width", options.width.max(2) as i32)
         .field("height", options.height.max(2) as i32)
@@ -155,6 +162,9 @@ pub(super) fn build_ges_timeline(
         )
     {
         let layer = timeline.append_layer();
+        if audio_only && timeline_track.kind == TrackKind::Text {
+            continue;
+        }
         if timeline_track.kind == TrackKind::Text {
             if !timeline_track.visible {
                 continue;
@@ -225,8 +235,11 @@ pub(super) fn build_ges_timeline(
             let asset = timeline_data
                 .asset(media.asset_id)
                 .ok_or_else(|| anyhow::anyhow!("Clip {} has no source media.", clip.id()))?;
-            let track_types =
+            let mut track_types =
                 exported_track_types(timeline_track, clip, asset.kind, asset.has_audio);
+            if audio_only {
+                track_types &= ges::TrackType::AUDIO;
+            }
             if track_types.is_empty() {
                 continue;
             }
@@ -289,7 +302,7 @@ pub(super) fn build_ges_timeline(
         }
     }
     let content_duration = timeline_data.duration(timeline_data.content_duration());
-    if !content_duration.is_zero() {
+    if !audio_only && !content_duration.is_zero() {
         // Appended layers have lower visual precedence, so this preserves the
         // timeline duration and supplies black frames without covering media.
         let background_layer = timeline.append_layer();
@@ -369,7 +382,7 @@ fn export_timeline_with_encoder(
     encoder: ExportEncoder,
     report_progress: &mut impl FnMut(f32),
 ) -> anyhow::Result<()> {
-    let timeline = build_ges_timeline(timeline_data, project_root, options)?;
+    let timeline = build_ges_timeline(timeline_data, project_root, options, false)?;
     let profile = encoding_profile(options);
     let _encoder_selection = EncoderSelection::for_export(encoder)?;
     let pipeline = ges::Pipeline::new();

--- a/rust/src/editor/export_gstreamer.rs
+++ b/rust/src/editor/export_gstreamer.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow, bail};
 use super::{
     clip_render_plan::{resolve_audio_clip_render_plan, resolve_visual_clip_render_plan},
     export::{ExportEncoder, ExportOptions},
@@ -23,12 +24,12 @@ pub(super) fn export_timeline(
     output: &Path,
     options: ExportOptions,
     mut report_progress: impl FnMut(f32),
-) -> anyhow::Result<()> {
+) -> Result<()> {
     if timeline.clips.is_empty() {
-        anyhow::bail!("Add at least one clip before exporting.");
+        bail!("Add at least one clip before exporting.");
     }
     ges::init().map_err(|error| {
-        anyhow::anyhow!("could not initialize GStreamer Editing Services: {error}")
+        anyhow!("could not initialize GStreamer Editing Services: {error}")
     })?;
     report_progress(0.0);
 
@@ -47,10 +48,10 @@ pub(super) fn export_timeline(
 
     if output.is_file() {
         fs::remove_file(output)
-            .map_err(|error| anyhow::anyhow!("could not replace {}: {error}", output.display()))?;
+            .map_err(|error| anyhow!("could not replace {}: {error}", output.display()))?;
     }
     fs::rename(&temporary_output.path, output).map_err(|error| {
-        anyhow::anyhow!(
+        anyhow!(
             "could not move completed export to {}: {error}",
             output.display()
         )
@@ -82,10 +83,10 @@ pub fn configure_text_clip(
     clip: &ges::TitleClip,
     properties: &TextClipProperties,
     output_scale: f64,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let font_size = (properties.font_size * output_scale).clamp(1.0, 1000.0);
     let Some((text_overlay, _)) = clip.lookup_child("font-desc") else {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "text renderer has no font property at {}:{}",
             file!(),
             line!()
@@ -107,7 +108,7 @@ pub fn configure_text_clip(
         ("ypos", properties.position_y.to_value()),
     ] {
         if let Err(error) = clip.set_child_property(name, value) {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "could not set text {name}: {error} at {}:{}",
                 file!(),
                 line!()
@@ -122,7 +123,7 @@ pub fn build_ges_timeline(
     project_root: &Path,
     options: ExportOptions,
     audio_only: bool,
-) -> anyhow::Result<ges::Timeline> {
+) -> Result<ges::Timeline> {
     let timeline = if audio_only {
         let timeline = ges::Timeline::new();
         timeline.add_track(&ges::AudioTrack::new())?;
@@ -178,10 +179,10 @@ pub fn build_ges_timeline(
             clips.sort_by_key(|clip| clip.timeline_start());
             for clip in clips {
                 let text = clip.text().ok_or_else(|| {
-                    anyhow::anyhow!("Media clip {} is on a text track.", clip.id())
+                    anyhow!("Media clip {} is on a text track.", clip.id())
                 })?;
                 let overlay = ges::TitleClip::new().ok_or_else(|| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "could not create text clip {} at {}:{}",
                         clip.id(),
                         file!(),
@@ -191,7 +192,7 @@ pub fn build_ges_timeline(
                 overlay
                     .set_name(Some(&format!("opencut-clip-{}", clip.id())))
                     .map_err(|error| {
-                        anyhow::anyhow!("could not identify clip {}: {error}", clip.id())
+                        anyhow!("could not identify clip {}: {error}", clip.id())
                     })?;
                 let (start, duration) = clip_clock_range(
                     timeline_data.settings.frame_rate,
@@ -199,7 +200,7 @@ pub fn build_ges_timeline(
                     clip.timeline_start(),
                 );
                 if !overlay.set_start(start) {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "could not set text clip {} start at {}:{}",
                         clip.id(),
                         file!(),
@@ -207,7 +208,7 @@ pub fn build_ges_timeline(
                     ));
                 }
                 if !overlay.set_duration(duration) {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "could not set text clip {} duration at {}:{}",
                         clip.id(),
                         file!(),
@@ -215,7 +216,7 @@ pub fn build_ges_timeline(
                     ));
                 }
                 layer.add_clip(&overlay).map_err(|error| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "could not add text clip {} to the timeline: {error}",
                         clip.id()
                     )
@@ -231,10 +232,10 @@ pub fn build_ges_timeline(
         for clip in clips {
             let media = clip
                 .media()
-                .ok_or_else(|| anyhow::anyhow!("Text clip {} is on a media track.", clip.id()))?;
+                .ok_or_else(|| anyhow!("Text clip {} is on a media track.", clip.id()))?;
             let asset = timeline_data
                 .asset(media.asset_id)
-                .ok_or_else(|| anyhow::anyhow!("Clip {} has no source media.", clip.id()))?;
+                .ok_or_else(|| anyhow!("Clip {} has no source media.", clip.id()))?;
             let mut track_types =
                 exported_track_types(timeline_track, clip, asset.kind, asset.has_audio);
             if audio_only {
@@ -248,10 +249,10 @@ pub fn build_ges_timeline(
             } else {
                 let source = project_root.join(&asset.path);
                 let uri = Url::from_file_path(&source).map_err(|_| {
-                    anyhow::anyhow!("could not convert {} to a file URL", source.display())
+                    anyhow!("could not convert {} to a file URL", source.display())
                 })?;
                 let uri_asset = ges::UriClipAsset::request_sync(uri.as_str()).map_err(|error| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "build_ges_timeline failed: could not inspect {}: {error}",
                         source.display()
                     )
@@ -269,7 +270,7 @@ pub fn build_ges_timeline(
             let ges_clip = layer
                 .add_asset(&uri_asset, start, inpoint, duration, track_types)
                 .map_err(|error| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "could not add {} to the export timeline: {error}",
                         asset.name
                     )
@@ -277,7 +278,7 @@ pub fn build_ges_timeline(
             ges_clip
                 .set_name(Some(&format!("opencut-clip-{}", clip.id())))
                 .map_err(|error| {
-                    anyhow::anyhow!("could not identify clip {}: {error}", clip.id())
+                    anyhow!("could not identify clip {}: {error}", clip.id())
                 })?;
             if track_types.contains(ges::TrackType::VIDEO) {
                 apply_video_transform(
@@ -307,20 +308,20 @@ pub fn build_ges_timeline(
         // timeline duration and supplies black frames without covering media.
         let background_layer = timeline.append_layer();
         let background = ges::TestClip::new()
-            .ok_or_else(|| anyhow::anyhow!("could not create the timeline background"))?;
+            .ok_or_else(|| anyhow!("could not create the timeline background"))?;
         background.set_supported_formats(ges::TrackType::VIDEO);
         background.set_vpattern(ges::VideoTestPattern::Black);
         background.set_mute(true);
         background
             .set_name(Some("opencut-black-background"))
             .map_err(|error| {
-                anyhow::anyhow!("could not identify the timeline background: {error}")
+                anyhow!("could not identify the timeline background: {error}")
             })?;
         if !background.set_duration(frame_clock_time(
             timeline_data.settings.frame_rate,
             timeline_data.content_duration(),
         )) {
-            anyhow::bail!(
+            bail!(
                 "could not set the timeline background duration at {}:{}",
                 file!(),
                 line!()
@@ -328,10 +329,10 @@ pub fn build_ges_timeline(
         }
         background_layer
             .add_clip(&background)
-            .map_err(|error| anyhow::anyhow!("could not add the timeline background: {error}"))?;
+            .map_err(|error| anyhow!("could not add the timeline background: {error}"))?;
     }
     if !timeline.commit_sync() {
-        anyhow::bail!("GStreamer could not commit the export timeline.");
+        bail!("GStreamer could not commit the export timeline.");
     }
     Ok(timeline)
 }
@@ -342,7 +343,7 @@ pub(super) fn apply_video_transform(
     asset: &MediaAsset,
     options: ExportOptions,
     properties: VideoClipProperties,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let plan = resolve_visual_clip_render_plan(
         properties,
         asset.width,
@@ -360,7 +361,7 @@ pub(super) fn apply_video_transform(
         ("height", rounded_i32(plan.visible.height).max(1)),
     ] {
         clip.set_child_property(name, value)
-            .map_err(|error| anyhow::anyhow!("could not apply video {name}: {error}"))?;
+            .map_err(|error| anyhow!("could not apply video {name}: {error}"))?;
     }
     Ok(())
 }
@@ -381,7 +382,7 @@ fn export_timeline_with_encoder(
     options: ExportOptions,
     encoder: ExportEncoder,
     report_progress: &mut impl FnMut(f32),
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let timeline = build_ges_timeline(timeline_data, project_root, options, false)?;
     let profile = encoding_profile(options);
     let _encoder_selection = EncoderSelection::for_export(encoder)?;
@@ -389,20 +390,20 @@ fn export_timeline_with_encoder(
     configure_export_elements(&pipeline, options.video_bit_rate);
     pipeline
         .set_timeline(&timeline)
-        .map_err(|error| anyhow::anyhow!("could not attach the export timeline: {error}"))?;
+        .map_err(|error| anyhow!("could not attach the export timeline: {error}"))?;
 
     let output_uri = Url::from_file_path(temporary_output).map_err(|_| {
-        anyhow::anyhow!(
+        anyhow!(
             "could not convert {} to a file URL",
             temporary_output.display()
         )
     })?;
     pipeline
         .set_render_settings(output_uri.as_str(), &profile)
-        .map_err(|error| anyhow::anyhow!("could not configure GStreamer export: {error}"))?;
+        .map_err(|error| anyhow!("could not configure GStreamer export: {error}"))?;
     pipeline
         .set_mode(ges::PipelineFlags::RENDER)
-        .map_err(|error| anyhow::anyhow!("could not enable GStreamer render mode: {error}"))?;
+        .map_err(|error| anyhow!("could not enable GStreamer render mode: {error}"))?;
 
     log::info!("Starting GStreamer export with {}", encoder.factory_name());
     let result = render_pipeline(
@@ -560,9 +561,9 @@ struct EncoderSelection {
 }
 
 impl EncoderSelection {
-    fn for_export(video_encoder: ExportEncoder) -> anyhow::Result<Self> {
+    fn for_export(video_encoder: ExportEncoder) -> Result<Self> {
         let Some(selected_video) = gst::ElementFactory::find(video_encoder.factory_name()) else {
-            anyhow::bail!(
+            bail!(
                 "GStreamer H.264 encoder `{}` is unavailable. [{}:{}]",
                 video_encoder.factory_name(),
                 file!(),
@@ -570,7 +571,7 @@ impl EncoderSelection {
             );
         };
         if gst::ElementFactory::find(AUDIO_ENCODER_FACTORY).is_none() {
-            anyhow::bail!(
+            bail!(
                 "GStreamer AAC encoder `{AUDIO_ENCODER_FACTORY}` is unavailable. [{}:{}]",
                 file!(),
                 line!()
@@ -605,20 +606,20 @@ fn render_pipeline(
     pipeline: &ges::Pipeline,
     duration: Duration,
     report_progress: &mut impl FnMut(f32),
-) -> anyhow::Result<()> {
+) -> Result<()> {
     pipeline
         .set_state(gst::State::Playing)
-        .map_err(|error| anyhow::anyhow!("could not start GStreamer export: {error}"))?;
+        .map_err(|error| anyhow!("could not start GStreamer export: {error}"))?;
     let bus = pipeline
         .bus()
-        .ok_or_else(|| anyhow::anyhow!("GStreamer export pipeline has no message bus."))?;
+        .ok_or_else(|| anyhow!("GStreamer export pipeline has no message bus."))?;
     let total = duration.as_secs_f64().max(f64::EPSILON);
     loop {
         if let Some(message) = bus.timed_pop(gst::ClockTime::from_mseconds(100)) {
             match message.view() {
                 gst::MessageView::Eos(..) => return Ok(()),
                 gst::MessageView::Error(error) => {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "GStreamer export failed: {}{}",
                         error.error(),
                         error
@@ -663,10 +664,10 @@ struct TemporaryOutput {
 }
 
 impl TemporaryOutput {
-    fn new(path: std::path::PathBuf) -> anyhow::Result<Self> {
+    fn new(path: std::path::PathBuf) -> Result<Self> {
         if path.is_file() {
             fs::remove_file(&path).map_err(|error| {
-                anyhow::anyhow!(
+                anyhow!(
                     "could not replace temporary export {}: {error}",
                     path.display()
                 )

--- a/rust/src/editor/global_settings.rs
+++ b/rust/src/editor/global_settings.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::PathBuf};
 
@@ -13,7 +14,7 @@ impl GlobalEditorSettings {
         load_settings(&settings_path(), &PathBuf::from(env!("CARGO_MANIFEST_DIR")))
     }
 
-    pub fn save(&self) -> anyhow::Result<()> {
+    pub fn save(&self) -> Result<()> {
         save_settings(&settings_path(), self)
     }
 }
@@ -34,10 +35,10 @@ fn load_settings(path: &std::path::Path, default_root: &std::path::Path) -> Glob
     }
 }
 
-fn save_settings(path: &std::path::Path, settings: &GlobalEditorSettings) -> anyhow::Result<()> {
+fn save_settings(path: &std::path::Path, settings: &GlobalEditorSettings) -> Result<()> {
     if let Some(directory) = path.parent() {
         if let Err(error) = fs::create_dir_all(directory) {
-            anyhow::bail!(
+            bail!(
                 "could not create {}: {error} at {}:{}",
                 directory.display(),
                 file!(),
@@ -47,14 +48,14 @@ fn save_settings(path: &std::path::Path, settings: &GlobalEditorSettings) -> any
     }
     let json = match serde_json::to_string_pretty(settings) {
         Ok(json) => json,
-        Err(error) => anyhow::bail!(
+        Err(error) => bail!(
             "could not serialize global settings: {error} at {}:{}",
             file!(),
             line!()
         ),
     };
     if let Err(error) = fs::write(&path, format!("{json}\n")) {
-        anyhow::bail!(
+        bail!(
             "could not write {}: {error} at {}:{}",
             path.display(),
             file!(),

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -56,6 +56,7 @@ mod timeline_video;
 mod track;
 mod track_ui;
 pub mod transcription;
+pub mod timeline_audio;
 mod waveform;
 
 use crate::playback_view::{DragPhase, PlaybackViewDelegate};

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -46,6 +46,7 @@ mod settings;
 mod srt;
 pub use srt::write_srt;
 mod timeline;
+pub mod timeline_audio;
 mod timeline_clip;
 mod timeline_clip_menu;
 mod timeline_document;
@@ -56,7 +57,6 @@ mod timeline_video;
 mod track;
 mod track_ui;
 pub mod transcription;
-pub mod timeline_audio;
 mod waveform;
 
 use crate::playback_view::{DragPhase, PlaybackViewDelegate};
@@ -352,6 +352,7 @@ impl Editor {
                 &active_timeline,
                 &self.project_root,
                 export::ExportOptions::from_timeline(&active_timeline),
+                false,
             )?;
             self.timeline = Some(
                 TimelineRuntimeState::new(timeline_path, active_timeline, ges_timeline)

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -1,8 +1,8 @@
-use anyhow::{Context as _, Result};
 use crate::{
     editor::{explorer_drag::AssetBeingDragged, preview::load_timeline_position_with_options},
     video::{FileVideoBackend, VideoBackend},
 };
+use anyhow::{Context as _, Result};
 use gpui::{
     App, Bounds, Context, CursorStyle, Entity, EventEmitter, FocusHandle, KeyBinding, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, PathPromptOptions, Pixels, Render,

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -1,8 +1,8 @@
+use anyhow::{Context as _, Result};
 use crate::{
     editor::{explorer_drag::AssetBeingDragged, preview::load_timeline_position_with_options},
     video::{FileVideoBackend, VideoBackend},
 };
-use anyhow::{Context as _, Result};
 use gpui::{
     App, Bounds, Context, CursorStyle, Entity, EventEmitter, FocusHandle, KeyBinding, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, PathPromptOptions, Pixels, Render,
@@ -315,7 +315,7 @@ impl Editor {
         relative_path: PathBuf,
         timeline: TimelineSerialization,
         cx: &mut Context<Self>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         if let Some(active_timeline) = self.timeline.as_ref() {
             active_timeline.save(&self.project_root);
         }

--- a/rust/src/editor/preview_audio.rs
+++ b/rust/src/editor/preview_audio.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, anyhow};
 use super::*;
 use gst::prelude::*;
 use gstreamer as gst;
@@ -13,19 +14,19 @@ pub(super) struct AudioBackend {
 }
 
 impl AudioBackend {
-    pub(super) fn new(url: &Url) -> anyhow::Result<Self> {
-        gst::init().map_err(|error| anyhow::anyhow!("could not initialize GStreamer: {error}"))?;
+    pub(super) fn new(url: &Url) -> Result<Self> {
+        gst::init().map_err(|error| anyhow!("could not initialize GStreamer: {error}"))?;
         let video_sink = gst::ElementFactory::make("fakesink")
             .build()
-            .map_err(|error| anyhow::anyhow!("could not create audio preview sink: {error}"))?;
+            .map_err(|error| anyhow!("could not create audio preview sink: {error}"))?;
         let pipeline = gst::ElementFactory::make("playbin")
             .property("uri", url.as_str())
             .property("video-sink", &video_sink)
             .build()
-            .map_err(|error| anyhow::anyhow!("could not create audio preview: {error}"))?;
+            .map_err(|error| anyhow!("could not create audio preview: {error}"))?;
         pipeline
             .set_state(gst::State::Paused)
-            .map_err(|error| anyhow::anyhow!("could not prepare audio preview: {error}"))?;
+            .map_err(|error| anyhow!("could not prepare audio preview: {error}"))?;
         let _ = pipeline.state(gst::ClockTime::from_seconds(2));
         Ok(Self { pipeline })
     }

--- a/rust/src/editor/preview_audio.rs
+++ b/rust/src/editor/preview_audio.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, anyhow};
 use super::*;
+use anyhow::{Result, anyhow};
 use gst::prelude::*;
 use gstreamer as gst;
 use std::{path::Path, time::Duration};

--- a/rust/src/editor/project_settings.rs
+++ b/rust/src/editor/project_settings.rs
@@ -1,4 +1,4 @@
-use anyhow::Context as _;
+use anyhow::{Context as _, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -37,10 +37,10 @@ pub fn load_project_local_settings(project_root: &Path) -> ProjectLocalSettings 
 pub fn save_project_local_settings(
     project_root: &Path,
     settings: &ProjectLocalSettings,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let path = project_local_settings_path(project_root);
     let Some(directory) = path.parent() else {
-        anyhow::bail!(
+        bail!(
             "project-local settings path had no parent directory at {}:{}",
             file!(),
             line!()

--- a/rust/src/editor/srt.rs
+++ b/rust/src/editor/srt.rs
@@ -1,6 +1,6 @@
+use anyhow::{Result, bail};
 use std::path::Path;
 
-use anyhow::Result;
 use opencut_player::transcribe::SRT;
 use ulid::Ulid;
 
@@ -8,7 +8,7 @@ use crate::editor::{FrameRate, TextClip, TextClipProperties};
 
 pub fn write_srt(path: &Path, srt: &SRT) -> Result<()> {
     if !path.is_absolute() {
-        anyhow::bail!(
+        bail!(
             "SRT output path must be absolute at {}:{}",
             file!(),
             line!()

--- a/rust/src/editor/tests/clip_placement.test.rs
+++ b/rust/src/editor/tests/clip_placement.test.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result};
 use super::*;
 use crate::editor::tests::TimelineTestExt;
 use crate::editor::timeline_clip::AudioClipProperties;
+use anyhow::Result;
 
 #[test]
 fn validates_one_clip_placement() {

--- a/rust/src/editor/tests/clip_placement.test.rs
+++ b/rust/src/editor/tests/clip_placement.test.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result};
 use super::*;
 use crate::editor::tests::TimelineTestExt;
 use crate::editor::timeline_clip::AudioClipProperties;
@@ -99,7 +100,7 @@ fn validates_one_clip_placement() {
     );
 }
 
-fn placement_rejection(result: anyhow::Result<()>) -> ClipPlacementRejection {
+fn placement_rejection(result: Result<()>) -> ClipPlacementRejection {
     result
         .unwrap_err()
         .downcast::<ClipPlacementRejection>()

--- a/rust/src/editor/tests/srt.test.rs
+++ b/rust/src/editor/tests/srt.test.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 #[test]
 fn parses_cues_at_the_requested_frame_rate() {
     let srt = SRT::from_string("1\n00:00:01,000 --> 00:00:02,500\nHello\nworld\n").unwrap();
-    let clips = srt_text_clips(&srt, FrameRate::new(24, 1)).unwrap();
+    let clips = srt_text_clips(&srt, FrameRate::new(24, 1));
 
     assert_eq!(clips.len(), 1);
     assert_eq!(clips[0].timeline_start.frames(), 24);

--- a/rust/src/editor/tests/timeline_audio.test.rs
+++ b/rust/src/editor/tests/timeline_audio.test.rs
@@ -13,7 +13,7 @@ fn renders_trimmed_audio_with_gaps_gain_and_no_output_files() {
     }
     std::fs::write(
         root.join("source.wav"),
-        opencut_player::transcribe::audio::finish_wav(input).unwrap(),
+        opencut_player::transcribe::audio::write_wav_header(input).unwrap(),
     )
     .unwrap();
     let mut timeline = TimelineSerialization::with_test_tracks();

--- a/rust/src/editor/tests/timeline_audio.test.rs
+++ b/rust/src/editor/tests/timeline_audio.test.rs
@@ -1,0 +1,170 @@
+use super::*;
+use crate::editor::tests::{TimelineTestExt, lock_gstreamer_test};
+use crate::editor::timeline_clip::{AudioClipProperties, VideoClip};
+
+#[test]
+fn renders_trimmed_audio_with_gaps_gain_and_no_output_files() {
+    let _lock = lock_gstreamer_test();
+    let root = std::env::temp_dir().join(format!("opencut-audio-{}", Ulid::generate()));
+    std::fs::create_dir(&root).unwrap();
+    let mut input = vec![0; 44];
+    for _ in 0..32_000 {
+        input.extend_from_slice(&8000_i16.to_le_bytes());
+    }
+    std::fs::write(
+        root.join("source.wav"),
+        opencut_player::transcribe::audio::finish_wav(input).unwrap(),
+    )
+    .unwrap();
+    let mut timeline = TimelineSerialization::with_test_tracks();
+    timeline.settings.frame_rate = FrameRate::new(30, 1);
+    let track_id = timeline
+        .tracks
+        .iter()
+        .find(|track| track.kind == TrackKind::Audio)
+        .unwrap()
+        .id;
+    let asset = media_probe::probe_asset(&root.join("source.wav")).unwrap();
+    let asset_id = asset.id;
+    let mut asset = asset;
+    asset.path = "source.wav".into();
+    timeline.assets.push(asset);
+    timeline.clips.push(Clip::Audio(AudioClip {
+        id: Ulid::generate(),
+        track_id,
+        asset_id,
+        timeline_start: TimelineTime::from_frames(30),
+        source_in: TimelineTime::from_frames(15),
+        source_out: TimelineTime::from_frames(45),
+        audio_properties: AudioClipProperties::default(),
+        video_properties: VideoClipProperties::default(),
+    }));
+    let wav = render_audio_wav(&timeline, &root).unwrap();
+    assert_eq!(wav.len(), 44 + 2 * 16_000 * 2);
+    let samples: Vec<_> = wav[44..]
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect();
+    assert!(samples[..15_900].iter().all(|sample| *sample == 0));
+    assert!(
+        samples[17_000..30_000]
+            .iter()
+            .any(|sample| sample.abs() > 1000)
+    );
+    timeline.clips[0]
+        .media_mut()
+        .unwrap()
+        .audio_properties
+        .gain_db = -6.020599913;
+    let quiet = render_audio_wav(&timeline, &root).unwrap();
+    let amplitude = i16::from_le_bytes(quiet[40044..40046].try_into().unwrap());
+    assert!((amplitude - 4000).abs() < 10, "{amplitude}");
+    let mut other_track = timeline
+        .tracks
+        .iter()
+        .find(|track| track.id == track_id)
+        .unwrap()
+        .clone();
+    other_track.id = Ulid::generate();
+    let mut overlapping = timeline.clips[0].clone();
+    overlapping.media_mut().unwrap().id = Ulid::generate();
+    overlapping.media_mut().unwrap().track_id = other_track.id;
+    timeline.tracks.push(other_track);
+    timeline.clips.push(overlapping);
+    let mixed = render_audio_wav(&timeline, &root).unwrap();
+    let amplitude = i16::from_le_bytes(mixed[40044..40046].try_into().unwrap());
+    assert!((amplitude - 8000).abs() < 20, "{amplitude}");
+    timeline.clips.pop();
+    timeline.tracks.pop();
+    let mut second = timeline.clips[0].clone();
+
+    second.media_mut().unwrap().id = Ulid::generate();
+    second.media_mut().unwrap().timeline_start = TimelineTime::from_frames(75);
+    timeline.clips.push(second);
+    let gaps = render_audio_wav(&timeline, &root).unwrap();
+    assert_eq!(gaps.len(), 44 + 56_000 * 2);
+    assert!(gaps[64044..78044].iter().all(|b| *b == 0));
+    timeline.clips.pop();
+    timeline.clips[0].media_mut().unwrap().timeline_start = TimelineTime::from_frames(499 * 30);
+    assert_eq!(
+        render_audio_wav(&timeline, &root).unwrap().len(),
+        44 + 500 * 16_000 * 2
+    );
+    timeline.clips[0].media_mut().unwrap().timeline_start = TimelineTime::from_frames(30);
+    std::fs::create_dir(root.join("nested")).unwrap();
+    timeline
+        .save(&root.join("nested/test.timeline.json"))
+        .unwrap();
+    let saved = TimelineSerialization::load(&root.join("nested/test.timeline.json")).unwrap();
+    assert_eq!(render_audio_wav(&saved, &root).unwrap(), quiet);
+    std::fs::remove_dir_all(root.join("nested")).unwrap();
+    assert_eq!(std::fs::read_dir(&root).unwrap().count(), 1);
+    timeline
+        .tracks
+        .iter_mut()
+        .find(|track| track.id == track_id)
+        .unwrap()
+        .muted = true;
+    assert!(
+        render_audio_wav(&timeline, &root)
+            .unwrap_err()
+            .to_string()
+            .contains("no enabled audio")
+    );
+    timeline
+        .tracks
+        .iter_mut()
+        .find(|track| track.id == track_id)
+        .unwrap()
+        .muted = false;
+    timeline.clips[0].media_mut().unwrap().timeline_start = TimelineTime::from_frames(500 * 30);
+    assert!(
+        render_audio_wav(&timeline, &root)
+            .unwrap_err()
+            .to_string()
+            .contains("500 seconds")
+    );
+    timeline.clips[0].media_mut().unwrap().timeline_start = TimelineTime::ZERO;
+    std::fs::remove_file(root.join("source.wav")).unwrap();
+    assert!(render_audio_wav(&timeline, &root).is_err());
+    timeline.clips.clear();
+    assert!(
+        render_audio_wav(&timeline, &root)
+            .unwrap_err()
+            .to_string()
+            .contains("positive")
+    );
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn renders_video_audio_without_video_tracks() {
+    let _lock = lock_gstreamer_test();
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let relative = PathBuf::from("data/tests/mini测试/地铁-出站-mini-480.mp4");
+    let mut asset = media_probe::probe_asset(&root.join(&relative)).unwrap();
+    asset.path = relative;
+    let asset_id = asset.id;
+    let mut timeline = TimelineSerialization::with_test_tracks();
+    timeline.settings.frame_rate = FrameRate::new(30, 1);
+    timeline.assets.push(asset);
+    let track_id = timeline
+        .tracks
+        .iter()
+        .find(|track| track.kind == TrackKind::Video)
+        .unwrap()
+        .id;
+    timeline.clips.push(Clip::Video(VideoClip {
+        id: Ulid::generate(),
+        track_id,
+        asset_id,
+        timeline_start: TimelineTime::ZERO,
+        source_in: TimelineTime::ZERO,
+        source_out: TimelineTime::from_frames(30),
+        audio_properties: AudioClipProperties::default(),
+        video_properties: VideoClipProperties::default(),
+    }));
+    let wav = render_audio_wav(&timeline, root).unwrap();
+    assert_eq!(wav.len(), 44 + 32_000);
+    assert!(wav[44..].iter().any(|byte| *byte != 0));
+}

--- a/rust/src/editor/tests/transcription.test.rs
+++ b/rust/src/editor/tests/transcription.test.rs
@@ -5,25 +5,30 @@ use std::{fs, path::Path};
 #[tokio::test]
 async fn rejects_missing_key_media_and_timeline_sources() {
     let directory = test_directory();
-    let error = start_transcription(directory.path.join("missing.mp4"), String::new())
-        .await
-        .unwrap_err();
-    assert!(error.to_string().contains("MiniMax API key"));
-    let error = start_transcription(directory.path.join("missing.mp4"), "test-key".into())
-        .await
-        .unwrap_err();
-    assert!(error.to_string().contains("unreadable_media"));
     let error = start_transcription(
-        directory.path.join("source.timeline.json"),
+        directory.path.join("missing.mp4"),
+        directory.path.clone(),
+        String::new(),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("MiniMax API key"));
+    let error = start_transcription(
+        directory.path.join("missing.mp4"),
+        directory.path.clone(),
         "test-key".into(),
     )
     .await
     .unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("timeline transcription is not supported")
-    );
+    assert!(error.to_string().contains("unreadable_media"));
+    let error = start_transcription(
+        directory.path.join("source.timeline.json"),
+        directory.path.clone(),
+        "test-key".into(),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("could not read"));
 }
 
 #[test]

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, anyhow};
 use super::*;
+use anyhow::{Result, anyhow};
 use gpui::point;
 pub use opencut_player::timeline::{
     FrameRate, TimelineSerialization, TimelineTime, TimelineViewState,

--- a/rust/src/editor/timeline.rs
+++ b/rust/src/editor/timeline.rs
@@ -1,5 +1,5 @@
-use super::*;
 use anyhow::{Result, anyhow};
+use super::*;
 use gpui::point;
 pub use opencut_player::timeline::{
     FrameRate, TimelineSerialization, TimelineTime, TimelineViewState,
@@ -47,12 +47,12 @@ pub fn timeline_ranges_overlap(
 }
 pub trait TimelineEditorExt: Sized {
     fn load(path: &Path) -> Result<Self>;
-    fn save(&self, path: &Path) -> anyhow::Result<()>;
+    fn save(&self, path: &Path) -> Result<()>;
     fn validate_clip_move_placements(
         &self,
         placements: &[(Ulid, Ulid, TimelineTime)],
         ignored_clip_ids: &HashSet<Ulid>,
-    ) -> anyhow::Result<()>;
+    ) -> Result<()>;
     fn set_frame_rate(&mut self, frame_rate: FrameRate);
     fn repair_and_prune_invalid_data(&mut self);
 }
@@ -84,7 +84,7 @@ impl TimelineEditorExt for TimelineSerialization {
         timeline.repair_and_prune_invalid_data();
         Ok(timeline)
     }
-    fn save(&self, path: &Path) -> anyhow::Result<()> {
+    fn save(&self, path: &Path) -> Result<()> {
         let Some(directory) = path.parent() else {
             return Err(anyhow!(
                 "timeline path has no parent directory at {}:{}",
@@ -134,7 +134,7 @@ impl TimelineEditorExt for TimelineSerialization {
         &self,
         placements: &[(Ulid, Ulid, TimelineTime)],
         ignored_clip_ids: &HashSet<Ulid>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         if placements.is_empty() {
             return Err(ClipPlacementRejection::NoPlacements.into());
         }
@@ -310,7 +310,7 @@ impl TimelineRuntimeState {
         path: PathBuf,
         data: TimelineSerialization,
         ges_timeline: gstreamer_editing_services::Timeline,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let scroll = ScrollHandle::new();
         scroll.set_offset(point(px(-data.view.horizontal_scroll), px(0.0)));
         let vertical_scroll = ScrollHandle::new();

--- a/rust/src/editor/timeline_audio.rs
+++ b/rust/src/editor/timeline_audio.rs
@@ -1,0 +1,134 @@
+use anyhow::anyhow;
+use super::*;
+use ges::prelude::*;
+use gstreamer as gst;
+use gstreamer_app as gst_app;
+use gstreamer_editing_services as ges;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Render the saved timeline's audio into a normalized WAV in memory.
+pub fn render_audio_wav(timeline: &TimelineSerialization, project_root: &Path) -> Result<Vec<u8>> {
+    let duration = timeline.duration(timeline.content_duration());
+    if duration.is_zero() || duration > Duration::from_secs(500) {
+        anyhow::bail!(
+            "timeline duration must be positive and at most 500 seconds (got {duration:?}) at {}:{}",
+            file!(),
+            line!()
+        );
+    }
+    let has_audio = timeline.tracks.iter().any(|track| {
+        timeline.clips_on_track(track.id).any(|clip| {
+            let Some(media) = clip.media() else {
+                return false;
+            };
+            let Some(asset) = timeline.asset(media.asset_id) else {
+                return false;
+            };
+            asset.has_audio
+                && !clip_render_plan::resolve_audio_clip_render_plan(
+                    track.muted,
+                    media.audio_properties,
+                )
+                .muted
+        })
+    });
+    if !has_audio {
+        anyhow::bail!(
+            "timeline contains no enabled audio clips at {}:{}",
+            file!(),
+            line!()
+        );
+    }
+    ges::init()?;
+    let ges_timeline = export_gstreamer::build_ges_timeline(
+        timeline,
+        project_root,
+        export::ExportOptions::from_timeline(timeline),
+        true,
+    )?;
+    let audio_sink = gst::parse::bin_from_description(
+        "audioconvert ! audioresample ! audio/x-raw,format=S16LE,rate=16000,channels=1,layout=interleaved ! appsink name=transcription_audio sync=false max-buffers=8 drop=false enable-last-sample=false",
+        true,
+    )?;
+    let sink = audio_sink
+        .by_name("transcription_audio")
+        .ok_or_else(|| anyhow!("missing audio sink at {}:{}", file!(), line!()))?
+        .downcast::<gst_app::AppSink>()
+        .map_err(|_| anyhow!("invalid audio sink type at {}:{}", file!(), line!()))?;
+    let pipeline = ges::Pipeline::new();
+    pipeline.preview_set_audio_sink(Some(&audio_sink));
+    pipeline.set_timeline(&ges_timeline)?;
+    pipeline.set_mode(ges::PipelineFlags::AUDIO_PREVIEW)?;
+    let bus = pipeline
+        .bus()
+        .ok_or_else(|| anyhow!("missing audio bus at {}:{}", file!(), line!()))?;
+    let result = collect_audio_wav(&pipeline, &sink, &bus, duration);
+    let stopped = pipeline.set_state(gst::State::Null);
+    let wav = result?;
+    stopped?;
+    Ok(wav)
+}
+
+fn collect_audio_wav(
+    pipeline: &ges::Pipeline,
+    sink: &gst_app::AppSink,
+    bus: &gst::Bus,
+    duration: Duration,
+) -> Result<Vec<u8>> {
+    let samples = (duration.as_secs_f64() * 16_000.0).round() as usize;
+    let mut wav = vec![0; 44 + samples * 2];
+    pipeline.set_state(gst::State::Playing)?;
+    let mut last_sample = Instant::now();
+    let mut received_audio = false;
+    loop {
+        if let Some(sample) = sink.try_pull_sample(gst::ClockTime::from_mseconds(100)) {
+            received_audio = true;
+            last_sample = Instant::now();
+            let buffer = sample.buffer().ok_or_else(|| {
+                anyhow!("missing audio buffer at {}:{}", file!(), line!())
+            })?;
+            let pts = buffer.pts().ok_or_else(|| {
+                anyhow!("missing audio timestamp at {}:{}", file!(), line!())
+            })?;
+            let start = ((pts.nseconds() as u128 * 16_000 + 500_000_000) / 1_000_000_000) as usize;
+            let data = buffer.map_readable()?;
+            if data.len() % 2 != 0 {
+                anyhow::bail!("unaligned audio buffer at {}:{}", file!(), line!());
+            }
+            if start < samples {
+                let count = data.len().min((samples - start) * 2);
+                wav[44 + start * 2..44 + start * 2 + count].copy_from_slice(&data[..count]);
+            }
+        }
+        while let Some(message) = bus.pop() {
+            if let gst::MessageView::Error(error) = message.view() {
+                anyhow::bail!(
+                    "timeline audio rendering failed: {:?} ({:?}) at {}:{}",
+                    error.error(),
+                    error.debug(),
+                    file!(),
+                    line!()
+                );
+            }
+        }
+        if sink.is_eos() {
+            break;
+        }
+        if last_sample.elapsed() > Duration::from_secs(60) {
+            anyhow::bail!(
+                "timeline audio rendering stalled at {}:{}",
+                file!(),
+                line!()
+            );
+        }
+    }
+    if !received_audio {
+        anyhow::bail!("timeline produced no audio at {}:{}", file!(), line!());
+    }
+    opencut_player::transcribe::audio::write_wav_header(wav)
+}
+
+#[cfg(test)]
+#[path = "tests/timeline_audio.test.rs"]
+mod tests;

--- a/rust/src/editor/timeline_audio.rs
+++ b/rust/src/editor/timeline_audio.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, bail};
 use super::*;
+use anyhow::{anyhow, bail};
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -7,14 +7,15 @@ use gstreamer_editing_services as ges;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use opencut_player::transcribe::MAX_TRANSCRIPTION_DURATION;
+
 /// Render the saved timeline's audio into a normalized WAV in memory.
 pub fn render_audio_wav(timeline: &TimelineSerialization, project_root: &Path) -> Result<Vec<u8>> {
     let duration = timeline.duration(timeline.content_duration());
-    if duration.is_zero() || duration > Duration::from_secs(500) {
+    if duration.is_zero() || duration > MAX_TRANSCRIPTION_DURATION {
         bail!(
-            "timeline duration must be positive and at most 500 seconds (got {duration:?}) at {}:{}",
-            file!(),
-            line!()
+            "timeline duration must be positive and at most {} seconds (got {duration:?})",
+            MAX_TRANSCRIPTION_DURATION.as_secs(),
         );
     }
     let has_audio = timeline.tracks.iter().any(|track| {
@@ -85,12 +86,12 @@ fn collect_audio_wav(
         if let Some(sample) = sink.try_pull_sample(gst::ClockTime::from_mseconds(100)) {
             received_audio = true;
             last_sample = Instant::now();
-            let buffer = sample.buffer().ok_or_else(|| {
-                anyhow!("missing audio buffer at {}:{}", file!(), line!())
-            })?;
-            let pts = buffer.pts().ok_or_else(|| {
-                anyhow!("missing audio timestamp at {}:{}", file!(), line!())
-            })?;
+            let buffer = sample
+                .buffer()
+                .ok_or_else(|| anyhow!("missing audio buffer at {}:{}", file!(), line!()))?;
+            let pts = buffer
+                .pts()
+                .ok_or_else(|| anyhow!("missing audio timestamp at {}:{}", file!(), line!()))?;
             let start = ((pts.nseconds() as u128 * 16_000 + 500_000_000) / 1_000_000_000) as usize;
             let data = buffer.map_readable()?;
             if data.len() % 2 != 0 {

--- a/rust/src/editor/timeline_audio.rs
+++ b/rust/src/editor/timeline_audio.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use super::*;
 use ges::prelude::*;
 use gstreamer as gst;
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 pub fn render_audio_wav(timeline: &TimelineSerialization, project_root: &Path) -> Result<Vec<u8>> {
     let duration = timeline.duration(timeline.content_duration());
     if duration.is_zero() || duration > Duration::from_secs(500) {
-        anyhow::bail!(
+        bail!(
             "timeline duration must be positive and at most 500 seconds (got {duration:?}) at {}:{}",
             file!(),
             line!()
@@ -34,7 +34,7 @@ pub fn render_audio_wav(timeline: &TimelineSerialization, project_root: &Path) -
         })
     });
     if !has_audio {
-        anyhow::bail!(
+        bail!(
             "timeline contains no enabled audio clips at {}:{}",
             file!(),
             line!()
@@ -94,7 +94,7 @@ fn collect_audio_wav(
             let start = ((pts.nseconds() as u128 * 16_000 + 500_000_000) / 1_000_000_000) as usize;
             let data = buffer.map_readable()?;
             if data.len() % 2 != 0 {
-                anyhow::bail!("unaligned audio buffer at {}:{}", file!(), line!());
+                bail!("unaligned audio buffer at {}:{}", file!(), line!());
             }
             if start < samples {
                 let count = data.len().min((samples - start) * 2);
@@ -103,7 +103,7 @@ fn collect_audio_wav(
         }
         while let Some(message) = bus.pop() {
             if let gst::MessageView::Error(error) = message.view() {
-                anyhow::bail!(
+                bail!(
                     "timeline audio rendering failed: {:?} ({:?}) at {}:{}",
                     error.error(),
                     error.debug(),
@@ -116,7 +116,7 @@ fn collect_audio_wav(
             break;
         }
         if last_sample.elapsed() > Duration::from_secs(60) {
-            anyhow::bail!(
+            bail!(
                 "timeline audio rendering stalled at {}:{}",
                 file!(),
                 line!()
@@ -124,7 +124,7 @@ fn collect_audio_wav(
         }
     }
     if !received_audio {
-        anyhow::bail!("timeline produced no audio at {}:{}", file!(), line!());
+        bail!("timeline produced no audio at {}:{}", file!(), line!());
     }
     opencut_player::transcribe::audio::write_wav_header(wav)
 }

--- a/rust/src/editor/timeline_document.rs
+++ b/rust/src/editor/timeline_document.rs
@@ -1,7 +1,7 @@
+use anyhow::{Context as _, Result, anyhow};
 use crate::editor::TimelineEditorExt;
 
 use super::timeline::TimelineSerialization;
-use anyhow::{Context as _, Result};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -15,7 +15,7 @@ pub(super) fn is_timeline_path(path: &Path) -> bool {
         .is_some_and(|name| name.ends_with(TIMELINE_SUFFIX))
 }
 
-pub(super) fn project_timeline_files(project_root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+pub(super) fn project_timeline_files(project_root: &Path) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     collect_timeline_files(project_root, project_root, &mut paths)?;
     paths.sort_by_key(|path| path.to_string_lossy().to_lowercase());
@@ -26,9 +26,9 @@ fn collect_timeline_files(
     project_root: &Path,
     directory: &Path,
     paths: &mut Vec<PathBuf>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     for entry in fs::read_dir(directory)
-        .map_err(|error| anyhow::anyhow!("could not read {}: {error}", directory.display()))?
+        .map_err(|error| anyhow!("could not read {}: {error}", directory.display()))?
         .filter_map(Result::ok)
     {
         let path = entry.path();
@@ -88,20 +88,20 @@ pub(super) fn create(
     project_root: &Path,
     relative_directory: &Path,
     name: &str,
-) -> anyhow::Result<(PathBuf, TimelineSerialization)> {
+) -> Result<(PathBuf, TimelineSerialization)> {
     let directory = project_root.join(relative_directory);
     if !directory.is_dir() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "{} is not a directory",
             directory.display()
         ));
     }
     let file_name = timeline_file_name(name)
-        .ok_or_else(|| anyhow::anyhow!("Enter a single non-empty timeline name."))?;
+        .ok_or_else(|| anyhow!("Enter a single non-empty timeline name."))?;
     let relative_path = relative_directory.join(&file_name);
     let path = project_root.join(&relative_path);
     if path.exists() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "{} already exists.",
             relative_path.display()
         ));
@@ -111,9 +111,9 @@ pub(super) fn create(
     Ok((relative_path, timeline))
 }
 
-fn timeline_file_names(directory: &Path) -> anyhow::Result<Vec<String>> {
+fn timeline_file_names(directory: &Path) -> Result<Vec<String>> {
     Ok(fs::read_dir(directory)
-        .map_err(|error| anyhow::anyhow!("could not read {}: {error}", directory.display()))?
+        .map_err(|error| anyhow!("could not read {}: {error}", directory.display()))?
         .filter_map(Result::ok)
         .filter_map(|entry| {
             let path = entry.path();

--- a/rust/src/editor/timeline_document.rs
+++ b/rust/src/editor/timeline_document.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context as _, Result, anyhow};
 use crate::editor::TimelineEditorExt;
+use anyhow::{Context as _, Result, anyhow};
 
 use super::timeline::TimelineSerialization;
 use std::{
@@ -91,20 +91,14 @@ pub(super) fn create(
 ) -> Result<(PathBuf, TimelineSerialization)> {
     let directory = project_root.join(relative_directory);
     if !directory.is_dir() {
-        return Err(anyhow!(
-            "{} is not a directory",
-            directory.display()
-        ));
+        return Err(anyhow!("{} is not a directory", directory.display()));
     }
     let file_name = timeline_file_name(name)
         .ok_or_else(|| anyhow!("Enter a single non-empty timeline name."))?;
     let relative_path = relative_directory.join(&file_name);
     let path = project_root.join(&relative_path);
     if path.exists() {
-        return Err(anyhow!(
-            "{} already exists.",
-            relative_path.display()
-        ));
+        return Err(anyhow!("{} already exists.", relative_path.display()));
     }
     let timeline = TimelineSerialization::default();
     timeline.save(&path)?;

--- a/rust/src/editor/timeline_track_menu.rs
+++ b/rust/src/editor/timeline_track_menu.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, bail};
 use super::*;
 
 impl Editor {
@@ -44,21 +45,21 @@ fn text_clip_at(
     timeline: &TimelineSerialization,
     track_id: Ulid,
     position: TimelineTime,
-) -> anyhow::Result<Clip> {
+) -> Result<Clip> {
     let Some(track) = timeline.track(track_id) else {
-        anyhow::bail!("The text track is unavailable.");
+        bail!("The text track is unavailable.");
     };
     if track.kind != TrackKind::Text {
-        anyhow::bail!("Text can only be added to a text track.");
+        bail!("Text can only be added to a text track.");
     }
     if track.locked {
-        anyhow::bail!("Unlock the text track before adding text.");
+        bail!("Unlock the text track before adding text.");
     }
     if timeline.clips_on_track(track_id).any(|clip| {
         clip.timeline_start() <= position
             && position < clip.timeline_end(timeline.settings.frame_rate)
     }) {
-        anyhow::bail!("A text clip already exists at this position.");
+        bail!("A text clip already exists at this position.");
     }
 
     let default_duration = timeline.ceil_time(5.0).max(TimelineTime::ONE_FRAME);

--- a/rust/src/editor/timeline_track_menu.rs
+++ b/rust/src/editor/timeline_track_menu.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
 use super::*;
+use anyhow::{Result, bail};
 
 impl Editor {
     pub(super) fn add_text(

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context as _, Result, anyhow, bail};
 use crate::video::VideoBackend;
+use anyhow::{Context as _, Result, anyhow, bail};
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -102,9 +102,7 @@ fn create_timeline_playback(timeline: &ges::Timeline) -> Result<VideoBackend> {
 }
 
 fn initialize_gstreamer() -> Result<()> {
-    ges::init().map_err(|error| {
-        anyhow!("could not initialize GStreamer Editing Services: {error}")
-    })
+    ges::init().map_err(|error| anyhow!("could not initialize GStreamer Editing Services: {error}"))
 }
 
 fn preview_audio_sink() -> Result<(gst::Element, gst_audio::StreamVolume)> {

--- a/rust/src/editor/timeline_video.rs
+++ b/rust/src/editor/timeline_video.rs
@@ -1,5 +1,5 @@
+use anyhow::{Context as _, Result, anyhow, bail};
 use crate::video::VideoBackend;
-use anyhow::{Context as _, Result};
 use ges::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -34,7 +34,7 @@ impl TimelineVideoBackend {
     }
 }
 
-pub fn refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::Result<()> {
+pub fn refresh_timeline_video_frame(playback: &mut VideoBackend) -> Result<()> {
     let position = playback.position();
     playback.seek(position).with_context(|| {
         format!(
@@ -45,14 +45,14 @@ pub fn refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::Resu
     })
 }
 
-pub fn try_refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::Result<()> {
+pub fn try_refresh_timeline_video_frame(playback: &mut VideoBackend) -> Result<()> {
     // A flushing seek cancels pending preroll. Let that frame reach the sink
     // before requesting another one, even when mouse events arrive faster.
     let (result, _, _) = playback.pipeline().state(gst::ClockTime::ZERO);
     match result {
         Ok(gst::StateChangeSuccess::Async) => return Ok(()),
         Err(error) => {
-            anyhow::bail!(
+            bail!(
                 "preview pipeline could not finish rendering: {error} at {}:{}",
                 file!(),
                 line!(),
@@ -66,27 +66,27 @@ pub fn try_refresh_timeline_video_frame(playback: &mut VideoBackend) -> anyhow::
 pub fn create_timeline_pipeline_v2(
     ges_timeline: &ges::Timeline,
     audio_sink: &gst::Element,
-) -> anyhow::Result<(gst::Pipeline, gst_app::AppSink)> {
+) -> Result<(gst::Pipeline, gst_app::AppSink)> {
     let video_sink = gst::parse::bin_from_description(
         "queue ! videoconvert ! appsink name=opencut_timeline_video drop=true max-buffers=3 enable-last-sample=false caps=video/x-raw,format=NV12,pixel-aspect-ratio=1/1",
         true,
     )
-    .map_err(|error| anyhow::anyhow!("could not create timeline preview video sink: {error}"))?;
+    .map_err(|error| anyhow!("could not create timeline preview video sink: {error}"))?;
     let sink = video_sink
         .by_name("opencut_timeline_video")
-        .ok_or_else(|| anyhow::anyhow!("timeline video appsink was not created"))?
+        .ok_or_else(|| anyhow!("timeline video appsink was not created"))?
         .downcast::<gst_app::AppSink>()
-        .map_err(|_| anyhow::anyhow!("timeline video sink had an unexpected type"))?;
+        .map_err(|_| anyhow!("timeline video sink had an unexpected type"))?;
 
     let pipeline = ges::Pipeline::new();
     pipeline.preview_set_video_sink(Some(&video_sink));
     pipeline.preview_set_audio_sink(Some(audio_sink));
     pipeline
         .set_timeline(ges_timeline)
-        .map_err(|error| anyhow::anyhow!("could not attach the preview timeline: {error}"))?;
+        .map_err(|error| anyhow!("could not attach the preview timeline: {error}"))?;
     pipeline
         .set_mode(ges::PipelineFlags::FULL_PREVIEW)
-        .map_err(|error| anyhow::anyhow!("could not enable GStreamer preview mode: {error}"))?;
+        .map_err(|error| anyhow!("could not enable GStreamer preview mode: {error}"))?;
 
     Ok((pipeline.upcast(), sink))
 }
@@ -101,23 +101,23 @@ fn create_timeline_playback(timeline: &ges::Timeline) -> Result<VideoBackend> {
     .context("create_timeline_playback failed")
 }
 
-fn initialize_gstreamer() -> anyhow::Result<()> {
+fn initialize_gstreamer() -> Result<()> {
     ges::init().map_err(|error| {
-        anyhow::anyhow!("could not initialize GStreamer Editing Services: {error}")
+        anyhow!("could not initialize GStreamer Editing Services: {error}")
     })
 }
 
-fn preview_audio_sink() -> anyhow::Result<(gst::Element, gst_audio::StreamVolume)> {
+fn preview_audio_sink() -> Result<(gst::Element, gst_audio::StreamVolume)> {
     let sink = gst::parse::bin_from_description(
         "audioconvert ! audioresample ! volume name=gpui_audio_volume ! autoaudiosink",
         true,
     )
-    .map_err(|error| anyhow::anyhow!("could not create timeline preview audio sink: {error}"))?;
+    .map_err(|error| anyhow!("could not create timeline preview audio sink: {error}"))?;
     let control = sink
         .by_name("gpui_audio_volume")
-        .ok_or_else(|| anyhow::anyhow!("timeline preview volume control was not created"))?
+        .ok_or_else(|| anyhow!("timeline preview volume control was not created"))?
         .dynamic_cast::<gst_audio::StreamVolume>()
-        .map_err(|_| anyhow::anyhow!("timeline preview volume control has an unexpected type"))?;
+        .map_err(|_| anyhow!("timeline preview volume control has an unexpected type"))?;
     Ok((sink.upcast(), control))
 }
 

--- a/rust/src/editor/transcription.rs
+++ b/rust/src/editor/transcription.rs
@@ -3,22 +3,30 @@ use opencut_player::transcribe::{self, Format, Options, SRT};
 
 /// Return merged SRT subtitles. The caller owns serialization and publication.
 /// Run on a Tokio executor; audio preparation runs directly on the caller's thread.
-pub async fn start_transcription(source: PathBuf, api_key: String) -> Result<SRT> {
+pub async fn start_transcription(
+    source: PathBuf,
+    project_root: PathBuf,
+    api_key: String,
+) -> Result<SRT> {
     if !source.is_absolute() {
         anyhow::bail!("transcription source must be an absolute file path");
     }
     if api_key.trim().is_empty() {
         anyhow::bail!("Set your MiniMax API key in Settings before generating SRT");
     }
-    if timeline_document::is_timeline_path(&source) {
-        anyhow::bail!("timeline transcription is not supported");
-    }
     let options = Options {
         format: Format::Srt,
         ..Options::default()
     };
     log::info!("Transcribing audio with MiniMax: {}", source.display());
-    let srt = transcribe::transcribe(&source, &api_key, &options).await?;
+    let srt = if timeline_document::is_timeline_path(&source) {
+        let timeline = TimelineSerialization::load(&source)?;
+        log::info!("Rendering timeline audio: {}", source.display());
+        let wav = super::timeline_audio::render_audio_wav(&timeline, &project_root)?;
+        transcribe::transcribe_wav(wav, &api_key, &options).await?
+    } else {
+        transcribe::transcribe(&source, &api_key, &options).await?
+    };
     transcribe::subtitles::merge_srt_sections(&srt)
 }
 

--- a/rust/src/editor/transcription.rs
+++ b/rust/src/editor/transcription.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail};
 use super::*;
 use opencut_player::transcribe::{self, Format, Options, SRT};
 
@@ -9,10 +10,10 @@ pub async fn start_transcription(
     api_key: String,
 ) -> Result<SRT> {
     if !source.is_absolute() {
-        anyhow::bail!("transcription source must be an absolute file path");
+        bail!("transcription source must be an absolute file path");
     }
     if api_key.trim().is_empty() {
-        anyhow::bail!("Set your MiniMax API key in Settings before generating SRT");
+        bail!("Set your MiniMax API key in Settings before generating SRT");
     }
     let options = Options {
         format: Format::Srt,

--- a/rust/src/editor/transcription.rs
+++ b/rust/src/editor/transcription.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail};
 use super::*;
+use anyhow::bail;
 use opencut_player::transcribe::{self, Format, Options, SRT};
 
 /// Return merged SRT subtitles. The caller owns serialization and publication.

--- a/rust/src/editor/waveform.rs
+++ b/rust/src/editor/waveform.rs
@@ -329,13 +329,13 @@ fn receive_waveform_samples(
     decoder: &mut ffmpeg::decoder::Audio,
     resampler: &mut ResamplingContext,
     builder: &mut WaveformBuilder,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let mut decoded = frame::Audio::empty();
     while decoder.receive_frame(&mut decoded).is_ok() {
         let mut converted = frame::Audio::empty();
         resampler
             .run(&decoded, &mut converted)
-            .map_err(|error| anyhow::anyhow!("could not resample waveform audio: {error}"))?;
+            .map_err(|error| anyhow!("could not resample waveform audio: {error}"))?;
         builder.push_samples(converted.plane::<f32>(0));
     }
     Ok(())

--- a/rust/src/examples/mp3.rs
+++ b/rust/src/examples/mp3.rs
@@ -22,7 +22,7 @@
 //! Two execution paths work together: the main thread decodes ahead, while
 //! CPAL repeatedly calls our callback to request the next buffer of sound.
 //! Channels carry owned sample blocks forward and completion/errors backward.
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Error, Result, bail};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ffmpeg_next as ffmpeg;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
@@ -152,7 +152,7 @@ fn run() -> Result<()> {
                 break;
             }
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(at!("Reading packet")));
+                return Err(Error::new(error).context(at!("Reading packet")));
             }
         }
         // Take every frame currently available before sending the next packet.
@@ -305,7 +305,7 @@ fn receive(
             // EAGAIN means "send more input before asking for more output".
             // This is normal flow control, not a damaged-file error.
             Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => return Ok(()),
-            Err(error) => return Err(anyhow::Error::new(error).context(at!("Decoding audio"))),
+            Err(error) => return Err(Error::new(error).context(at!("Decoding audio"))),
         }
         // Some files omit speaker positions. Supply a conventional layout
         // based on channel count so the resampler has a usable description.

--- a/rust/src/examples/mp4-v2.rs
+++ b/rust/src/examples/mp4-v2.rs
@@ -22,7 +22,7 @@
 //!
 //! Subtitles, rotation metadata, and scrubbing are still omitted.
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Error, Result, bail};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ffmpeg_next as ffmpeg;
 use gpui::{
@@ -749,7 +749,7 @@ fn decode(
         };
         let stream = output(&device, &config, receiver, reporter, timeline.clone())?;
         stream.play().context(at!("Starting audio"))?;
-        Ok::<_, anyhow::Error>(Some(Audio {
+        Ok::<_, Error>(Some(Audio {
             index,
             decoder,
             resampler,
@@ -796,7 +796,7 @@ fn decode(
                 Ok(()) => {}
                 Err(ffmpeg::Error::Eof) => break,
                 Err(error) => {
-                    return Err(anyhow::Error::new(error).context(at!("Reading media packet")));
+                    return Err(Error::new(error).context(at!("Reading media packet")));
                 }
             }
             if packet.stream() == track.index {
@@ -895,7 +895,7 @@ fn receive_video(
             Err(ffmpeg::Error::Eof) => return Ok(()),
             Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => return Ok(()),
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(at!("Decoding video frame")));
+                return Err(Error::new(error).context(at!("Decoding video frame")));
             }
         }
         let time = track.seconds(decoded.timestamp(), *next_time);
@@ -960,7 +960,7 @@ fn locate(
                     break;
                 }
                 Err(error) => {
-                    return Err(anyhow::Error::new(error).context(at!("Reading while seeking")));
+                    return Err(Error::new(error).context(at!("Reading while seeking")));
                 }
             }
             if packet.stream() != track.index {
@@ -980,7 +980,7 @@ fn locate(
                     Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => break,
                     Err(error) => {
                         return Err(
-                            anyhow::Error::new(error).context(at!("Decoding while seeking"))
+                            Error::new(error).context(at!("Decoding while seeking"))
                         );
                     }
                 }
@@ -1263,7 +1263,7 @@ fn receive(
             Ok(()) => {}
             Err(ffmpeg::Error::Eof) => return Ok(()),
             Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => return Ok(()),
-            Err(error) => return Err(anyhow::Error::new(error).context(at!("Decoding audio"))),
+            Err(error) => return Err(Error::new(error).context(at!("Decoding audio"))),
         }
         let decoded_layout = layout(decoder.channels(), decoded.channel_layout());
         decoded.set_channel_layout(decoded_layout);

--- a/rust/src/examples/mp4-v2.rs
+++ b/rust/src/examples/mp4-v2.rs
@@ -979,9 +979,7 @@ fn locate(
                     }
                     Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => break,
                     Err(error) => {
-                        return Err(
-                            Error::new(error).context(at!("Decoding while seeking"))
-                        );
+                        return Err(Error::new(error).context(at!("Decoding while seeking")));
                     }
                 }
                 // receive_frame hands back presentation order, so the last

--- a/rust/src/examples/mp4.rs
+++ b/rust/src/examples/mp4.rs
@@ -9,7 +9,7 @@
 //! shared wall clock, not a production audio-device clock with drift correction.
 //! Seeking, subtitles, rotation metadata, and playback controls are omitted.
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Error, Result, bail};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ffmpeg_next as ffmpeg;
 use gpui::{
@@ -383,7 +383,7 @@ fn decode(path: &Path, pictures: &SyncSender<Message>) -> Result<()> {
             clock + Duration::from_secs_f64(offset),
         )?;
         stream.play().context(at!("Starting audio"))?;
-        Ok::<_, anyhow::Error>(Some(Audio {
+        Ok::<_, Error>(Some(Audio {
             index,
             decoder,
             resampler,
@@ -401,7 +401,7 @@ fn decode(path: &Path, pictures: &SyncSender<Message>) -> Result<()> {
             Ok(()) => {}
             Err(ffmpeg::Error::Eof) => break,
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(at!("Reading media packet")));
+                return Err(Error::new(error).context(at!("Reading media packet")));
             }
         }
         if packet.stream() == index {
@@ -505,7 +505,7 @@ fn receive_video(
             Err(ffmpeg::Error::Eof) => return Ok(()),
             Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => return Ok(()),
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(at!("Decoding video frame")));
+                return Err(Error::new(error).context(at!("Decoding video frame")));
             }
         }
         // PTS says WHEN a picture belongs on screen, independently of how fast
@@ -766,7 +766,7 @@ fn receive(
             Ok(()) => {}
             Err(ffmpeg::Error::Eof) => return Ok(()),
             Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => return Ok(()),
-            Err(error) => return Err(anyhow::Error::new(error).context(at!("Decoding audio"))),
+            Err(error) => return Err(Error::new(error).context(at!("Decoding audio"))),
         }
         let decoded_layout = layout(decoder.channels(), decoded.channel_layout());
         decoded.set_channel_layout(decoded_layout);

--- a/rust/src/transcribe/README.md
+++ b/rust/src/transcribe/README.md
@@ -32,3 +32,14 @@ From the repository root, run module tests with:
 ```sh
 bash rust/scripts/cargo-cli.sh test --locked --no-default-features --features transcribe --lib
 ```
+
+The editor also supports Generate SRT for saved timeline files. It resolves media
+against the event's project root and renders only audio through GES into an
+in-memory mono 16 kHz PCM WAV. Track/clip mute, gain, trims, overlaps, and timeline
+silence are preserved. Empty timelines, timelines without enabled audio, and
+timelines longer than 500 seconds are rejected before rendering.
+
+Call `transcribe_wav(wav, api_key, &Options).await` to transcribe normalized WAV
+bytes directly. It validates the WAV format and duration before uploading and
+returns parsed SRT. The editor merges cues and writes only the final SRT to the
+project root; it creates no intermediate audio files.

--- a/rust/src/transcribe/audio.rs
+++ b/rust/src/transcribe/audio.rs
@@ -106,6 +106,15 @@ pub fn extract_audio_as_wav(path: &Path) -> Result<Vec<u8>> {
             wav.extend_from_slice(&((mono * i16::MAX as f32).round() as i16).to_le_bytes());
         }
     }
+    write_wav_header(wav)
+}
+
+/// Complete a mono 16 kHz PCM WAV buffer with 44 reserved header bytes.
+pub fn write_wav_header(mut wav: Vec<u8>) -> Result<Vec<u8>> {
+    const RATE: u32 = 16_000;
+    if wav.len() < 44 || wav.len() - 44 > (u32::MAX - 36) as usize || (wav.len() - 44) % 2 != 0 {
+        anyhow::bail!("invalid PCM WAV buffer at {}:{}", file!(), line!());
+    }
     let size = (wav.len() - 44) as u32;
     if size == 0 {
         return Err(anyhow::anyhow!(

--- a/rust/src/transcribe/audio.rs
+++ b/rust/src/transcribe/audio.rs
@@ -6,12 +6,7 @@ use std::{collections::VecDeque, path::Path, time::Duration};
 /// Unknown duration is left to the caller's decoded-audio validation.
 pub fn audio_duration(path: &Path) -> Result<Option<Duration>> {
     if let Err(error) = ffmpeg::init() {
-        return Err(anyhow!(
-            "ffmpeg_init: {} at {}:{}",
-            error,
-            file!(),
-            line!()
-        ));
+        return Err(anyhow!("ffmpeg_init: {} at {}:{}", error, file!(), line!()));
     }
     let input = match ffmpeg::format::input(path) {
         Ok(input) => input,
@@ -69,12 +64,7 @@ pub fn extract_audio_as_wav(path: &Path) -> Result<Vec<u8>> {
     match ffmpeg::init() {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow!(
-                "ffmpeg_init: {} at {}:{}",
-                error,
-                file!(),
-                line!()
-            ));
+            return Err(anyhow!("ffmpeg_init: {} at {}:{}", error, file!(), line!()));
         }
     };
     let mut reader = AudioReader::open(path, RATE)?;

--- a/rust/src/transcribe/audio.rs
+++ b/rust/src/transcribe/audio.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use ffmpeg_next as ffmpeg;
 use std::{collections::VecDeque, path::Path, time::Duration};
 
@@ -6,7 +6,7 @@ use std::{collections::VecDeque, path::Path, time::Duration};
 /// Unknown duration is left to the caller's decoded-audio validation.
 pub fn audio_duration(path: &Path) -> Result<Option<Duration>> {
     if let Err(error) = ffmpeg::init() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "ffmpeg_init: {} at {}:{}",
             error,
             file!(),
@@ -16,7 +16,7 @@ pub fn audio_duration(path: &Path) -> Result<Option<Duration>> {
     let input = match ffmpeg::format::input(path) {
         Ok(input) => input,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "unreadable_media: {} at {}:{}",
                 error,
                 file!(),
@@ -25,7 +25,7 @@ pub fn audio_duration(path: &Path) -> Result<Option<Duration>> {
         }
     };
     let Some(stream) = input.streams().best(ffmpeg::media::Type::Audio) else {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "missing_audio: {} at {}:{}",
             "file contains no audio stream",
             file!(),
@@ -53,7 +53,7 @@ pub fn audio_duration(path: &Path) -> Result<Option<Duration>> {
     }
     match Duration::try_from_secs_f64(duration) {
         Ok(duration) => Ok(Some(duration)),
-        Err(error) => Err(anyhow::anyhow!(
+        Err(error) => Err(anyhow!(
             "invalid_duration: {} at {}:{}",
             error,
             file!(),
@@ -69,7 +69,7 @@ pub fn extract_audio_as_wav(path: &Path) -> Result<Vec<u8>> {
     match ffmpeg::init() {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "ffmpeg_init: {} at {}:{}",
                 error,
                 file!(),
@@ -87,7 +87,7 @@ pub fn extract_audio_as_wav(path: &Path) -> Result<Vec<u8>> {
         reader.advance(delay)?;
         let end = reader.queue_start as i128 + reader.queue.len() as i128;
         if end > i128::from((u32::MAX - 36) / 2) {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "audio_too_large: {} at {}:{}",
                 "decoded audio exceeds the PCM WAV size limit",
                 file!(),
@@ -113,11 +113,11 @@ pub fn extract_audio_as_wav(path: &Path) -> Result<Vec<u8>> {
 pub fn write_wav_header(mut wav: Vec<u8>) -> Result<Vec<u8>> {
     const RATE: u32 = 16_000;
     if wav.len() < 44 || wav.len() - 44 > (u32::MAX - 36) as usize || (wav.len() - 44) % 2 != 0 {
-        anyhow::bail!("invalid PCM WAV buffer at {}:{}", file!(), line!());
+        bail!("invalid PCM WAV buffer at {}:{}", file!(), line!());
     }
     let size = (wav.len() - 44) as u32;
     if size == 0 {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "missing_audio: {} at {}:{}",
             "no audio samples decoded",
             file!(),
@@ -159,7 +159,7 @@ impl AudioReader {
         let input = match ffmpeg::format::input(path) {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "unreadable_media: {} at {}:{}",
                     error,
                     file!(),
@@ -168,7 +168,7 @@ impl AudioReader {
             }
         };
         let Some(stream) = input.streams().best(ffmpeg::media::Type::Audio) else {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "missing_audio: {} at {}:{}",
                 "no audio stream",
                 file!(),
@@ -178,7 +178,7 @@ impl AudioReader {
         let context = match ffmpeg::codec::context::Context::from_parameters(stream.parameters()) {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "decode_failure: {} at {}:{}",
                     error,
                     file!(),
@@ -189,7 +189,7 @@ impl AudioReader {
         let mut decoder = match context.decoder().audio() {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "decode_failure: {} at {}:{}",
                     error,
                     file!(),
@@ -210,7 +210,7 @@ impl AudioReader {
         ) {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "resample_failure: {} at {}:{}",
                     error,
                     file!(),
@@ -248,7 +248,7 @@ impl AudioReader {
             match self.input.seek(seek, ..seek) {
                 Ok(value) => value,
                 Err(error) => {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "seek_failure: {} at {}:{}",
                         error,
                         file!(),
@@ -304,7 +304,7 @@ impl AudioReader {
                         (Some(sample), _) => sample,
                         (None, Some(timestamp)) => timestamp,
                         (None, None) => {
-                            return Err(anyhow::anyhow!(
+                            return Err(anyhow!(
                                 "missing_pts: {} at {}:{}",
                                 "audio frame has no presentation timestamp",
                                 file!(),
@@ -323,7 +323,7 @@ impl AudioReader {
                     match self.resampler.run(&decoded, &mut converted) {
                         Ok(value) => value,
                         Err(error) => {
-                            return Err(anyhow::anyhow!(
+                            return Err(anyhow!(
                                 "resample_failure: {} at {}:{}",
                                 error,
                                 file!(),
@@ -343,7 +343,7 @@ impl AudioReader {
                     let delay = match self.resampler.flush(&mut converted) {
                         Ok(value) => value,
                         Err(error) => {
-                            return Err(anyhow::anyhow!(
+                            return Err(anyhow!(
                                 "resample_failure: {} at {}:{}",
                                 error,
                                 file!(),
@@ -357,7 +357,7 @@ impl AudioReader {
                 }
                 Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => {}
                 Err(error) => {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "decode_failure: {} at {}:{}",
                         error,
                         file!(),
@@ -376,7 +376,7 @@ impl AudioReader {
                         match self.decoder.send_packet(&packet) {
                             Ok(value) => value,
                             Err(error) => {
-                                return Err(anyhow::anyhow!(
+                                return Err(anyhow!(
                                     "decode_failure: {} at {}:{}",
                                     error,
                                     file!(),
@@ -390,7 +390,7 @@ impl AudioReader {
                     match self.decoder.send_eof() {
                         Ok(value) => value,
                         Err(error) => {
-                            return Err(anyhow::anyhow!(
+                            return Err(anyhow!(
                                 "decode_failure: {} at {}:{}",
                                 error,
                                 file!(),
@@ -401,7 +401,7 @@ impl AudioReader {
                     self.eof = true;
                 }
                 Err(error) => {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "decode_failure: {} at {}:{}",
                         error,
                         file!(),

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -79,6 +79,42 @@ pub async fn transcribe_response(path: &Path, api_key: &str, options: &Options) 
         ));
     }
     let wav = extract_audio_as_wav(path)?;
+    transcribe_wav_response(wav, api_key, options).await
+}
+
+/// Transcribe normalized mono 16 kHz PCM WAV bytes without filesystem access.
+pub async fn transcribe_wav(wav: Vec<u8>, api_key: &str, options: &Options) -> Result<SRT> {
+    let options = Options {
+        format: Format::Srt,
+        language: options.language.clone(),
+    };
+    let response = transcribe_wav_response(wav, api_key, &options).await?;
+    let Some(text) = response.as_str() else {
+        anyhow::bail!("expected SRT response at {}:{}", file!(), line!());
+    };
+    SRT::from_string(text)
+}
+
+async fn transcribe_wav_response(wav: Vec<u8>, api_key: &str, options: &Options) -> Result<Value> {
+    if api_key.trim().is_empty() {
+        anyhow::bail!(
+            "missing_api_key: an API key is required at {}:{}",
+            file!(),
+            line!()
+        );
+    }
+    if wav.len() <= 44 || wav.len() % 2 != 0 {
+        anyhow::bail!("invalid WAV data at {}:{}", file!(), line!());
+    }
+    let header = wav[..44].to_vec();
+    let wav = audio::write_wav_header(wav)?;
+    if header != wav[..44] {
+        anyhow::bail!(
+            "expected mono 16 kHz 16-bit PCM WAV at {}:{}",
+            file!(),
+            line!()
+        );
+    }
     // Extraction produces a 44-byte header followed by mono 16 kHz, 16-bit PCM.
     let audio_bytes = wav.len() - 44;
     if audio_bytes > 500 * 16_000 * 2 {

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1,6 +1,6 @@
 //! MiniMax ASR for local media. Credentials belong to the caller, not library state.
+use anyhow::{Result, anyhow, bail};
 use self::audio::extract_audio_as_wav;
-use anyhow::Result;
 use reqwest::{
     Client,
     header::{AUTHORIZATION, HeaderValue},
@@ -49,7 +49,7 @@ pub async fn transcribe(path: &Path, api_key: &str, options: &Options) -> Result
     };
     let response = transcribe_response(path, api_key, &options).await?;
     let Some(text) = response.as_str() else {
-        anyhow::bail!("expected SRT response at {}:{}", file!(), line!());
+        bail!("expected SRT response at {}:{}", file!(), line!());
     };
     SRT::from_string(text)
 }
@@ -58,7 +58,7 @@ pub async fn transcribe(path: &Path, api_key: &str, options: &Options) -> Result
 /// HTTP is asynchronous; FFmpeg decoding blocks the caller's background thread.
 pub async fn transcribe_response(path: &Path, api_key: &str, options: &Options) -> Result<Value> {
     if api_key.trim().is_empty() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "missing_api_key: {} at {}:{}",
             "an API key is required for transcription",
             file!(),
@@ -69,7 +69,7 @@ pub async fn transcribe_response(path: &Path, api_key: &str, options: &Options) 
         && duration > Duration::from_secs(500)
     {
         let duration = duration.as_secs_f64();
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "audio_too_long: {} at {}:{}",
             format!(
                 "audio duration is {duration:.6} seconds; transcription accepts at most 500 seconds"
@@ -90,26 +90,26 @@ pub async fn transcribe_wav(wav: Vec<u8>, api_key: &str, options: &Options) -> R
     };
     let response = transcribe_wav_response(wav, api_key, &options).await?;
     let Some(text) = response.as_str() else {
-        anyhow::bail!("expected SRT response at {}:{}", file!(), line!());
+        bail!("expected SRT response at {}:{}", file!(), line!());
     };
     SRT::from_string(text)
 }
 
 async fn transcribe_wav_response(wav: Vec<u8>, api_key: &str, options: &Options) -> Result<Value> {
     if api_key.trim().is_empty() {
-        anyhow::bail!(
+        bail!(
             "missing_api_key: an API key is required at {}:{}",
             file!(),
             line!()
         );
     }
     if wav.len() <= 44 || wav.len() % 2 != 0 {
-        anyhow::bail!("invalid WAV data at {}:{}", file!(), line!());
+        bail!("invalid WAV data at {}:{}", file!(), line!());
     }
     let header = wav[..44].to_vec();
     let wav = audio::write_wav_header(wav)?;
     if header != wav[..44] {
-        anyhow::bail!(
+        bail!(
             "expected mono 16 kHz 16-bit PCM WAV at {}:{}",
             file!(),
             line!()
@@ -119,7 +119,7 @@ async fn transcribe_wav_response(wav: Vec<u8>, api_key: &str, options: &Options)
     let audio_bytes = wav.len() - 44;
     if audio_bytes > 500 * 16_000 * 2 {
         let duration = audio_bytes as f64 / (16_000.0 * 2.0);
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "audio_too_long: {} at {}:{}",
             format!(
                 "audio duration is {duration:.6} seconds; transcription accepts at most 500 seconds"
@@ -137,7 +137,7 @@ async fn transcribe_wav_response(wav: Vec<u8>, api_key: &str, options: &Options)
     {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "transcription_request: {} at {}:{}",
                 error,
                 file!(),
@@ -165,7 +165,7 @@ async fn request(
     let mut authorization = match HeaderValue::from_str(&format!("Bearer {api_key}")) {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "invalid_api_key: {} at {}:{}",
                 error,
                 file!(),
@@ -180,7 +180,7 @@ async fn request(
     {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "transcription_request: {} at {}:{}",
                 error,
                 file!(),
@@ -204,7 +204,7 @@ async fn request(
             match HeaderValue::from_str(language) {
                 Ok(value) => value,
                 Err(error) => {
-                    return Err(anyhow::anyhow!(
+                    return Err(anyhow!(
                         "invalid_language: {} at {}:{}",
                         error,
                         file!(),
@@ -217,7 +217,7 @@ async fn request(
     let response = match request.send().await {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "transcription_request: {} at {}:{}",
                 error,
                 file!(),
@@ -229,7 +229,7 @@ async fn request(
     let bytes = match response.bytes().await {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "transcription_request: {} at {}:{}",
                 error,
                 file!(),
@@ -240,7 +240,7 @@ async fn request(
     let body = match std::str::from_utf8(&bytes) {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "invalid_transcription_response: {} at {}:{}",
                 error,
                 file!(),
@@ -258,7 +258,7 @@ async fn request(
             .get("request_id")
             .and_then(Value::as_str)
             .unwrap_or("unavailable");
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "transcription_api: {} at {}:{}",
             format!(
                 "HTTP {status}: {} (request_id: {})",
@@ -275,7 +275,7 @@ async fn request(
     let value: Value = match serde_json::from_str(body) {
         Ok(value) => value,
         Err(error) => {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "invalid_transcription_response: {} at {}:{}",
                 error,
                 file!(),
@@ -289,7 +289,7 @@ async fn request(
             .and_then(Value::as_f64)
             .is_some_and(|n| n.is_finite() && n >= 0.0)
     {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "invalid_transcription_response: {} at {}:{}",
             "expected transcript text and duration",
             file!(),
@@ -298,7 +298,7 @@ async fn request(
     }
     if matches!(options.format, Format::VerboseJson) {
         let Some(segments) = value.get("segments").and_then(Value::as_array) else {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "invalid_transcription_response: {} at {}:{}",
                 "expected timestamped segments",
                 file!(),
@@ -320,7 +320,7 @@ async fn request(
                     || !segment.get("text").is_some_and(Value::is_string)
             })
         {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "invalid_transcription_response: {} at {}:{}",
                 "invalid speaker or segment fields",
                 file!(),

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1,6 +1,6 @@
 //! MiniMax ASR for local media. Credentials belong to the caller, not library state.
-use anyhow::{Result, anyhow, bail};
 use self::audio::extract_audio_as_wav;
+use anyhow::{Result, anyhow, bail};
 use reqwest::{
     Client,
     header::{AUTHORIZATION, HeaderValue},
@@ -11,6 +11,8 @@ use std::{path::Path, time::Duration};
 pub mod audio;
 pub mod subtitles;
 pub use subtitles::{SRT, Subtitle};
+
+pub const MAX_TRANSCRIPTION_DURATION: Duration = Duration::from_secs(500);
 
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
@@ -66,13 +68,14 @@ pub async fn transcribe_response(path: &Path, api_key: &str, options: &Options) 
         ));
     }
     if let Some(duration) = audio::audio_duration(path)?
-        && duration > Duration::from_secs(500)
+        && duration > MAX_TRANSCRIPTION_DURATION
     {
         let duration = duration.as_secs_f64();
         return Err(anyhow!(
             "audio_too_long: {} at {}:{}",
             format!(
-                "audio duration is {duration:.6} seconds; transcription accepts at most 500 seconds"
+                "audio duration is {duration:.6} seconds; transcription accepts at most {} seconds",
+                MAX_TRANSCRIPTION_DURATION.as_secs()
             ),
             file!(),
             line!()
@@ -117,12 +120,13 @@ async fn transcribe_wav_response(wav: Vec<u8>, api_key: &str, options: &Options)
     }
     // Extraction produces a 44-byte header followed by mono 16 kHz, 16-bit PCM.
     let audio_bytes = wav.len() - 44;
-    if audio_bytes > 500 * 16_000 * 2 {
+    if audio_bytes as u128 > MAX_TRANSCRIPTION_DURATION.as_nanos() * 16_000 * 2 / 1_000_000_000 {
         let duration = audio_bytes as f64 / (16_000.0 * 2.0);
         return Err(anyhow!(
             "audio_too_long: {} at {}:{}",
             format!(
-                "audio duration is {duration:.6} seconds; transcription accepts at most 500 seconds"
+                "audio duration is {duration:.6} seconds; transcription accepts at most {} seconds",
+                MAX_TRANSCRIPTION_DURATION.as_secs()
             ),
             file!(),
             line!()

--- a/rust/src/transcribe/subtitles.rs
+++ b/rust/src/transcribe/subtitles.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use std::{fmt, time::Duration};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -25,14 +25,14 @@ impl SRT {
             }
             let mut lines = block.lines();
             if let Err(error) = lines.next().unwrap_or("").parse::<u64>() {
-                anyhow::bail!(
+                bail!(
                     "invalid_srt: invalid cue number: {error} at {}:{}",
                     file!(),
                     line!()
                 );
             }
             let Some((start, end)) = lines.next().unwrap_or("").split_once(" --> ") else {
-                anyhow::bail!(
+                bail!(
                     "invalid_srt: expected SRT time range at {}:{}",
                     file!(),
                     line!()
@@ -42,7 +42,7 @@ impl SRT {
             let end = Duration::from_millis(timestamp_ms(end)?);
             let text = lines.collect::<Vec<_>>().join("\n");
             if end <= start || text.trim().is_empty() {
-                anyhow::bail!(
+                bail!(
                     "invalid_srt: invalid cue duration or empty text at {}:{}",
                     file!(),
                     line!()
@@ -87,7 +87,7 @@ pub fn merge_srt_sections(srt: &SRT) -> Result<SRT> {
     for subtitle in &srt.subtitles {
         if let Some(previous) = merged.subtitles.last_mut() {
             if subtitle.start < previous.start {
-                anyhow::bail!(
+                bail!(
                     "invalid_srt: cues must be ordered by start time at {}:{}",
                     file!(),
                     line!()
@@ -115,7 +115,7 @@ fn timestamp_ms(timestamp: &str) -> Result<u64> {
             .iter()
             .all(|part| part.bytes().all(|byte| byte.is_ascii_digit()))
     {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "invalid_srt: {} at {}:{}",
             format!("invalid timestamp: {timestamp}"),
             file!(),
@@ -127,7 +127,7 @@ fn timestamp_ms(timestamp: &str) -> Result<u64> {
         *value = match part.parse::<u64>() {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "invalid_srt: {} at {}:{}",
                     error,
                     file!(),
@@ -138,7 +138,7 @@ fn timestamp_ms(timestamp: &str) -> Result<u64> {
     }
     let [hours, minutes, seconds, millis] = values;
     if minutes >= 60 || seconds >= 60 {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "invalid_srt: {} at {}:{}",
             format!("invalid timestamp: {timestamp}"),
             file!(),
@@ -149,7 +149,7 @@ fn timestamp_ms(timestamp: &str) -> Result<u64> {
         .checked_mul(3_600_000)
         .and_then(|total| total.checked_add(minutes * 60_000 + seconds * 1000 + millis))
     else {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "invalid_srt: {} at {}:{}",
             format!("timestamp overflow: {timestamp}"),
             file!(),

--- a/rust/src/transcribe/subtitles.rs
+++ b/rust/src/transcribe/subtitles.rs
@@ -127,12 +127,7 @@ fn timestamp_ms(timestamp: &str) -> Result<u64> {
         *value = match part.parse::<u64>() {
             Ok(value) => value,
             Err(error) => {
-                return Err(anyhow!(
-                    "invalid_srt: {} at {}:{}",
-                    error,
-                    file!(),
-                    line!()
-                ));
+                return Err(anyhow!("invalid_srt: {} at {}:{}", error, file!(), line!()));
             }
         };
     }

--- a/rust/src/transcribe/tests/transcribe.test.rs
+++ b/rust/src/transcribe/tests/transcribe.test.rs
@@ -204,3 +204,51 @@ fn server(status: u16, body: Vec<u8>, delay: Duration) -> (String, JoinHandle<Ve
     });
     (url, handle)
 }
+
+#[tokio::test]
+async fn memory_audio_rejects_invalid_and_overlong_wav_before_upload() {
+    let options = Options::default();
+    assert!(transcribe_wav(vec![], "test-key", &options).await.is_err());
+    let mut wav = audio::finish_wav(vec![0; 44 + 320]).unwrap();
+    wav[24] = 0;
+    assert!(
+        transcribe_wav(wav, "test-key", &options)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("PCM WAV")
+    );
+    let wav = audio::finish_wav(vec![0; 44 + 500 * 32_000 + 2]).unwrap();
+    assert!(
+        transcribe_wav(wav, "test-key", &options)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("audio_too_long")
+    );
+}
+
+#[tokio::test]
+async fn uploads_memory_wav_and_parses_mergeable_srt() {
+    let body =
+        "1\n00:00:00,000 --> 00:00:00,100\nhello \n\n2\n00:00:00,100 --> 00:00:00,200\nworld\n";
+    let (url, server) = server(200, body.as_bytes().to_vec(), Duration::ZERO);
+    let wav = audio::finish_wav(vec![0; 44 + 6400]).unwrap();
+    let response = request(
+        &client(),
+        &url,
+        "test-key",
+        wav.clone(),
+        &Options {
+            format: Format::Srt,
+            language: None,
+        },
+    )
+    .await
+    .unwrap();
+    let srt = SRT::from_string(response.as_str().unwrap()).unwrap();
+    let merged = subtitles::merge_srt_sections(&srt).unwrap();
+    assert_eq!(merged.subtitles[0].text, "hello world");
+    let received = server.join().unwrap();
+    assert!(received.windows(wav.len()).any(|part| part == wav));
+}

--- a/rust/src/transcribe/tests/transcribe.test.rs
+++ b/rust/src/transcribe/tests/transcribe.test.rs
@@ -209,7 +209,7 @@ fn server(status: u16, body: Vec<u8>, delay: Duration) -> (String, JoinHandle<Ve
 async fn memory_audio_rejects_invalid_and_overlong_wav_before_upload() {
     let options = Options::default();
     assert!(transcribe_wav(vec![], "test-key", &options).await.is_err());
-    let mut wav = audio::finish_wav(vec![0; 44 + 320]).unwrap();
+    let mut wav = audio::write_wav_header(vec![0; 44 + 320]).unwrap();
     wav[24] = 0;
     assert!(
         transcribe_wav(wav, "test-key", &options)
@@ -218,7 +218,7 @@ async fn memory_audio_rejects_invalid_and_overlong_wav_before_upload() {
             .to_string()
             .contains("PCM WAV")
     );
-    let wav = audio::finish_wav(vec![0; 44 + 500 * 32_000 + 2]).unwrap();
+    let wav = audio::write_wav_header(vec![0; 44 + 500 * 32_000 + 2]).unwrap();
     assert!(
         transcribe_wav(wav, "test-key", &options)
             .await
@@ -233,7 +233,7 @@ async fn uploads_memory_wav_and_parses_mergeable_srt() {
     let body =
         "1\n00:00:00,000 --> 00:00:00,100\nhello \n\n2\n00:00:00,100 --> 00:00:00,200\nworld\n";
     let (url, server) = server(200, body.as_bytes().to_vec(), Duration::ZERO);
-    let wav = audio::finish_wav(vec![0; 44 + 6400]).unwrap();
+    let wav = audio::write_wav_header(vec![0; 44 + 6400]).unwrap();
     let response = request(
         &client(),
         &url,

--- a/rust/src/video2/audio.rs
+++ b/rust/src/video2/audio.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Error, Result, bail};
 use std::{
     path::Path,
     sync::{Arc, Mutex, mpsc},
@@ -5,7 +6,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Context as _, Result, bail};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ffmpeg_next as ffmpeg;
 
@@ -184,7 +184,7 @@ impl Audio {
                     return Ok(());
                 }
                 Err(error) => {
-                    return Err(anyhow::Error::new(error).context(format!(
+                    return Err(Error::new(error).context(format!(
                         "Decoding audio frame at {}:{}",
                         file!(),
                         line!()
@@ -392,7 +392,7 @@ fn run(
                 ended = true;
             }
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(format!(
+                return Err(Error::new(error).context(format!(
                     "Reading audio packet at {}:{}",
                     file!(),
                     line!()

--- a/rust/src/video2/decoder.rs
+++ b/rust/src/video2/decoder.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Error, Result, bail};
 use std::{
     collections::VecDeque,
     path::Path,
@@ -6,7 +7,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Context as _, Result, bail};
 use ffmpeg_next as ffmpeg;
 
 use super::decompression::Decompression;
@@ -227,7 +227,7 @@ pub fn run(
                 media.eof = true;
             }
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(format!(
+                return Err(Error::new(error).context(format!(
                     "Reading media packet at {}:{}",
                     file!(),
                     line!()
@@ -600,7 +600,7 @@ fn locate(
                 draining = true;
             }
             Err(error) => {
-                return Err(anyhow::Error::new(error).context(format!(
+                return Err(Error::new(error).context(format!(
                     "Reading media while seeking at {}:{}",
                     file!(),
                     line!()

--- a/rust/src/video2/decompression.rs
+++ b/rust/src/video2/decompression.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Error, Result};
 use ffmpeg_next as ffmpeg;
 
 #[cfg(target_os = "macos")]
@@ -94,7 +94,7 @@ impl Decompression {
                     Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::error::EAGAIN => {
                         Ok(None)
                     }
-                    Err(error) => Err(anyhow::Error::new(error).context(format!(
+                    Err(error) => Err(Error::new(error).context(format!(
                         "Decoding software video at {}:{}",
                         file!(),
                         line!()

--- a/rust/src/video2/mod.rs
+++ b/rust/src/video2/mod.rs
@@ -10,6 +10,7 @@
 //! Enable the `ffmpeg-backend` Cargo feature to use this module.
 //! Enable `ffmpeg-video` for GPUI's `video(&backend)?.id(...).size(...)` element.
 
+use anyhow::{Context as _, Error, Result, anyhow, bail};
 use std::{
     path::Path,
     sync::{Arc, Mutex, MutexGuard, mpsc},
@@ -17,7 +18,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Context as _, Result, bail};
 use ffmpeg_next::frame::Video;
 
 mod audio;
@@ -266,7 +266,7 @@ impl VideoBackend {
             reply,
         };
         if self.commands.send(request).is_err() {
-            let error = anyhow::anyhow!("Video decoder disconnected at {}:{}", file!(), line!());
+            let error = anyhow!("Video decoder disconnected at {}:{}", file!(), line!());
             state.fail(&error);
             return Err(error);
         }
@@ -338,7 +338,7 @@ impl State {
         Ok(())
     }
 
-    fn fail(&mut self, error: &anyhow::Error) {
+    fn fail(&mut self, error: &Error) {
         if matches!(self.status, Status::Failed(_) | Status::Stopped) {
             return;
         }
@@ -416,7 +416,7 @@ fn seek_result(
             // Preserve the decoder's actual failure rather than hiding it behind
             // a disconnected completion channel.
             lock(shared).check()?;
-            Err(anyhow::Error::new(error).context(format!(
+            Err(Error::new(error).context(format!(
                 "Waiting for video seek at {}:{}",
                 file!(),
                 line!()
@@ -492,7 +492,7 @@ fn present(
                     state.clock.set_paused(!resume, Instant::now());
                     let _ = request.reply.try_send(Ok(()));
                 } else {
-                    let _ = request.reply.try_send(Err(anyhow::anyhow!(
+                    let _ = request.reply.try_send(Err(anyhow!(
                         "Seek superseded at {}:{}",
                         file!(),
                         line!()

--- a/rust/src/video2/tests.rs
+++ b/rust/src/video2/tests.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow};
 use super::*;
+use anyhow::anyhow;
 use std::{
     future::Future,
     path::PathBuf,

--- a/rust/src/video2/tests.rs
+++ b/rust/src/video2/tests.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow};
 use super::*;
 use std::{
     future::Future,
@@ -290,7 +291,7 @@ fn playback_after_seek_keeps_the_lookahead_frame() -> Result<()> {
 fn terminal_errors_are_reported_without_an_update_call() -> Result<()> {
     let fixture = Fixture::new("0")?;
     let mut backend = VideoBackend::open_sync(&fixture.0)?;
-    lock(&backend.shared).fail(&anyhow::anyhow!(
+    lock(&backend.shared).fail(&anyhow!(
         "Injected decoder failure at {}:{}",
         file!(),
         line!()

--- a/rust/src/video2/video_element.test.rs
+++ b/rust/src/video2/video_element.test.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow};
 use super::*;
 use ffmpeg_next as ffmpeg;
 use std::{
@@ -42,7 +43,7 @@ fn constructor_defaults_builders_and_backend_errors() -> Result<()> {
     let element = element.id("video").size(px(400.0), px(300.0));
     assert_eq!(element.id, Some("video".into()));
     assert_eq!((element.width, element.height), (px(400.0), px(300.0)));
-    super::super::lock(&backend.shared).fail(&anyhow::anyhow!(
+    super::super::lock(&backend.shared).fail(&anyhow!(
         "Injected failure at {}:{}",
         file!(),
         line!()

--- a/rust/src/video2/video_element.test.rs
+++ b/rust/src/video2/video_element.test.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow};
 use super::*;
+use anyhow::anyhow;
 use ffmpeg_next as ffmpeg;
 use std::{
     sync::{Mutex, mpsc},


### PR DESCRIPTION
Enable **Generate SRT** for timeline files selected in the explorer. Load the selected timeline, render its audio through GStreamer into memory, and upload WAV bytes to MiniMax. Only the final merged SRT is written to disk.

- Preserve clip trims, positions, overlaps, gain, mute settings, and silence.
- Add `transcribe_wav` and shared WAV-header construction.
- Share the 500-second limit across timeline, audio, and video transcription.
- Standardize unqualified anyhow imports and document the rule.