### PR TITLE
Add preview text selection & fix HEVC black frames bug

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,8 +2,8 @@
 cli = "run --config .cargo/cli.toml --quiet --no-default-features --features cli --bin opencut --"
 editor-mac = "run --config .cargo/macos.toml --no-default-features --features editor --bin opencut-editor"
 editor-win = "run --config .cargo/windows.toml --no-default-features --features editor --bin opencut-editor"
-test-mac = "test --config .cargo/macos.toml"
-test-win = "test --config .cargo/windows.toml"
+test-mac = ["test", "--config", ".cargo/macos.toml", "--config", "env.RUST_TEST_THREADS=\"1\""]
+test-win = ["test", "--config", ".cargo/windows.toml", "--config", "env.RUST_TEST_THREADS=\"1\""]
 player-mac = "run --config .cargo/macos.toml --no-default-features --features player --bin opencut-player"
 player-win = "run --config .cargo/windows.toml --no-default-features --features player --bin opencut-player"
 build-editor-mac = "build --config .cargo/macos.toml --no-default-features --features editor --bin opencut-editor"

--- a/rust/src/cli/engine/probe.rs
+++ b/rust/src/cli/engine/probe.rs
@@ -229,7 +229,12 @@ pub fn inspect_assets(
             Ok(p) => p,
             Err(e) => {
                 findings.push(crate::cli::validate::Finding {
-                    error: e.context(format!("/assets/{i}/path ({}), at {}:{}", path.display(), file!(), line!())),
+                    error: e.context(format!(
+                        "/assets/{i}/path ({}), at {}:{}",
+                        path.display(),
+                        file!(),
+                        line!()
+                    )),
                     fix_hint: None,
                 });
                 continue;

--- a/rust/src/cli/main.rs
+++ b/rust/src/cli/main.rs
@@ -75,7 +75,11 @@ async fn main() -> ExitCode {
 
 fn print_error(error: &opencut_player::cli::error::Error, json: bool) {
     if json {
-        let _ = writeln!(io::stdout().lock(), "{}", json!({"error": {"message": format!("{error:#}")}}));
+        let _ = writeln!(
+            io::stdout().lock(),
+            "{}",
+            json!({"error": {"message": format!("{error:#}")}})
+        );
     } else {
         let _ = writeln!(io::stderr().lock(), "{error:#}");
     }

--- a/rust/src/cli/validate.rs
+++ b/rust/src/cli/validate.rs
@@ -14,7 +14,10 @@ pub struct Finding {
 }
 
 impl Serialize for Finding {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
         let mut state = serializer.serialize_struct("Finding", 2)?;
         state.serialize_field("message", &format!("{:#}", self.error))?;

--- a/rust/src/editor/clip_render_plan.rs
+++ b/rust/src/editor/clip_render_plan.rs
@@ -1,16 +1,9 @@
 use super::timeline_clip::{AudioClipProperties, VideoClipProperties};
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct RenderRect {
-    pub left: f64,
-    pub top: f64,
-    pub width: f64,
-    pub height: f64,
-}
+use gpui::{Bounds, point, size};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VisualClipRenderPlan {
-    pub visible: RenderRect,
+    pub visible: Bounds<f64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45,12 +38,10 @@ pub fn resolve_visual_clip_render_plan(
     let full_height = source_height as f64 * source_scale;
     let center_x = target_width * 0.5 + properties.position_x * project_scale;
     let center_y = target_height * 0.5 + properties.position_y * project_scale;
-    let visible = RenderRect {
-        left: center_x - full_width * 0.5,
-        top: center_y - full_height * 0.5,
-        width: full_width,
-        height: full_height,
-    };
+    let visible = Bounds::new(
+        point(center_x - full_width * 0.5, center_y - full_height * 0.5),
+        size(full_width, full_height),
+    );
 
     VisualClipRenderPlan { visible }
 }

--- a/rust/src/editor/debug_state.rs
+++ b/rust/src/editor/debug_state.rs
@@ -1,0 +1,281 @@
+use super::{Editor, preview::PreviewTarget};
+use anyhow::{Context as _, Result};
+use gpui::{ClipboardItem, Context};
+use gstreamer as gst;
+use gstreamer_editing_services::prelude::*;
+use gstreamer_video::{VideoFrameExt, VideoFrameRef, VideoInfo};
+use serde_json::{Value, json};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+impl Editor {
+    pub fn copy_debug_state(&mut self, cx: &mut Context<Self>) {
+        match debug_state(self) {
+            Ok(report) => {
+                cx.write_to_clipboard(ClipboardItem::new_string(report));
+                self.status = Some("Debug state copied. Paste it into the bug report.".into());
+            }
+            Err(error) => {
+                log::error!("Could not dump debug state: {error:?}");
+                self.status = Some(format!("Could not dump debug state: {error:?}"));
+            }
+        }
+        cx.notify();
+    }
+}
+
+fn debug_state(editor: &Editor) -> Result<String> {
+    let target = match &editor.preview.target {
+        PreviewTarget::None => "None",
+        PreviewTarget::Timeline => "Timeline",
+        PreviewTarget::VideoFile(_, _) => "VideoFile",
+        PreviewTarget::AudioFile(_, _) => "AudioFile",
+        PreviewTarget::ImageFile(_) => "ImageFile",
+    };
+    // Deliberately select fields rather than serializing the application/global settings.
+    let mut report = json!({
+        "format": "OpenCut debug state v1",
+        "version": env!("CARGO_PKG_VERSION"),
+        "captured_unix_ms": SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis(),
+        "notes": "Live snapshot; fields may change during playback. No credentials, environment, or raw media bytes are included. Timeline text and asset paths are included.",
+        "preview": {
+            "target": target,
+            "fullscreen": editor.preview.fullscreen,
+            "scrubbing": editor.preview.is_scrubbing,
+            "transform_drag_active": editor.preview.timeline_drag.is_some(),
+        },
+        "status": editor.status,
+        "export_running": editor.export.running,
+        "timeline": null,
+    });
+    if let Some(timeline) = &editor.timeline {
+        let playback = timeline.video_backend.playback();
+        let pipeline = playback.pipeline();
+        let position_before = playback.position();
+        let (state_result, state, pending) = pipeline.state(gst::ClockTime::ZERO);
+        let mut layers = Vec::new();
+        for layer in timeline.video_backend.ges_timeline().layers() {
+            let mut clips = Vec::new();
+            for clip in layer.clips() {
+                let mut properties = serde_json::Map::new();
+                for name in [
+                    "text",
+                    "font-desc",
+                    "color",
+                    "foreground-color",
+                    "background-color",
+                    "alpha",
+                    "posx",
+                    "posy",
+                    "xpos",
+                    "ypos",
+                    "width",
+                    "height",
+                    "text-x",
+                    "text-y",
+                    "text-width",
+                    "text-height",
+                ] {
+                    let Some((object, property)) = clip.lookup_child(name) else {
+                        continue;
+                    };
+                    if property.flags().contains(gst::glib::ParamFlags::READABLE) {
+                        properties.insert(name.into(), property_snapshot(&object, property.name()));
+                    }
+                }
+                clips.push(json!({
+                    "name": clip.name().as_deref(), "type": clip.type_().name(),
+                    "start_ns": clip.start().nseconds(), "duration_ns": clip.duration().nseconds(),
+                    "inpoint_ns": clip.inpoint().nseconds(),
+                    "formats": format!("{:?}", clip.supported_formats()),
+                    "properties": properties,
+                }));
+            }
+            layers.push(json!({"priority": layer.priority(), "clips": clips}));
+        }
+        let mut elements = Vec::new();
+        let mut iterator = pipeline.iterate_recurse();
+        let mut graph_note = None;
+        loop {
+            if elements.len() == 256 {
+                graph_note = Some("Element list capped at 256".to_string());
+                break;
+            }
+            let element = match iterator.next() {
+                Ok(Some(element)) => element,
+                Ok(None) => break,
+                Err(error) => {
+                    graph_note = Some(format!(
+                        "Graph changed or could not be read: {error:?} at {}:{}",
+                        file!(),
+                        line!()
+                    ));
+                    break;
+                }
+            };
+            let (_, state, pending) = element.state(gst::ClockTime::ZERO);
+            let mut pads = Vec::new();
+            for pad in element.pads() {
+                let caps = pad.current_caps();
+                pads.push(json!({
+                    "name": pad.name().as_str(), "direction": format!("{:?}", pad.direction()),
+                    "linked": pad.is_linked(), "active": pad.is_active(),
+                    "caps": caps.as_ref().map(|caps| caps.to_string()),
+                    "properties": object_properties(pad.upcast_ref()),
+                }));
+            }
+            elements.push(json!({
+                "name": element.name().as_str(),
+                "factory": element.factory().as_ref().map(|factory| factory.name().to_string()),
+                "state": format!("{state:?}"), "pending": format!("{pending:?}"),
+                "properties": object_properties(element.upcast_ref()), "pads": pads,
+            }));
+        }
+        let frame = match playback.get_current_frame() {
+            Some(sample) => frame_snapshot(&sample),
+            None => json!({"present": false}),
+        };
+        report["timeline"] = json!({
+            "path": timeline.path,
+            "in_memory": serde_json::to_value(&timeline.data).context(format!("Serializing live timeline at {}:{}", file!(), line!()))?,
+            "selected_clip_id": timeline.interaction.selected_clip_id,
+            "selected_clip_ids": timeline.interaction.selected_clip_ids,
+            "undo_count": timeline.undo_stack.len(), "redo_count": timeline.redo_stack.len(),
+            "playback": {
+                "position_before_ns": position_before.as_nanos(),
+                "position_after_ns": playback.position().as_nanos(),
+                "duration_ns": playback.duration().as_nanos(),
+                "state": format!("{state:?}"), "pending": format!("{pending:?}"),
+                "state_result": format!("{state_result:?}"),
+                "volume": playback.volume(), "frame": frame,
+            },
+            "ges_layers": layers, "pipeline_elements": elements, "graph_note": graph_note,
+        });
+    }
+    let json = serde_json::to_string_pretty(&report).context(format!(
+        "Formatting debug state at {}:{}",
+        file!(),
+        line!()
+    ))?;
+    Ok(format!("OpenCut debug state\n```json\n{json}\n```"))
+}
+
+fn object_properties(object: &gst::glib::Object) -> Value {
+    let mut properties = serde_json::Map::new();
+    // Never dump arbitrary object properties: URI/location and other strings may contain secrets.
+    for name in [
+        "alpha",
+        "posx",
+        "posy",
+        "xpos",
+        "ypos",
+        "width",
+        "height",
+        "zorder",
+        "operator",
+        "foreground-color",
+        "background-color",
+        "pattern",
+        "silent",
+        "sync",
+        "qos",
+        "is-live",
+        "ignore-inactive-pads",
+        "repeat-after-eos",
+        "max-last-buffer-repeat",
+        "drop",
+        "max-buffers",
+    ] {
+        let Some(property) = object.find_property(name) else {
+            continue;
+        };
+        if property.flags().contains(gst::glib::ParamFlags::READABLE) {
+            properties.insert(name.into(), property_snapshot(object, name));
+        }
+    }
+    Value::Object(properties)
+}
+
+fn property_snapshot(object: &gst::glib::Object, name: &str) -> Value {
+    match object.property_value(name).serialize() {
+        Ok(value) => json!(value.as_str()),
+        Err(error) => json!({"error": format!("{error:?} at {}:{}", file!(), line!())}),
+    }
+}
+
+fn frame_snapshot(sample: &gst::Sample) -> Value {
+    let mut result = json!({"present": true, "caps": sample.caps().map(|caps| caps.to_string())});
+    let Some(buffer) = sample.buffer() else {
+        return result;
+    };
+    result["pts_ns"] = json!(buffer.pts().map(|time| time.nseconds()));
+    result["dts_ns"] = json!(buffer.dts().map(|time| time.nseconds()));
+    result["duration_ns"] = json!(buffer.duration().map(|time| time.nseconds()));
+    result["bytes"] = json!(buffer.size());
+    result["flags"] = json!(format!("{:?}", buffer.flags()));
+    let Some(caps) = sample.caps() else {
+        return result;
+    };
+    let info = match VideoInfo::from_caps(caps) {
+        Ok(info) => info,
+        Err(error) => {
+            result["error"] = json!(format!("Video caps: {error:?} at {}:{}", file!(), line!()));
+            return result;
+        }
+    };
+    result["width"] = json!(info.width());
+    result["height"] = json!(info.height());
+    if info.format() != gstreamer_video::VideoFormat::Nv12 {
+        return result;
+    }
+    let frame = match VideoFrameRef::from_buffer_ref_readable(buffer, &info) {
+        Ok(frame) => frame,
+        Err(error) => {
+            result["error"] = json!(format!(
+                "Reading frame: {error:?} at {}:{}",
+                file!(),
+                line!()
+            ));
+            return result;
+        }
+    };
+    result["strides"] = json!(frame.info().stride());
+    let plane = match frame.plane_data(0) {
+        Ok(plane) => plane,
+        Err(error) => {
+            result["error"] = json!(format!(
+                "Reading luma: {error:?} at {}:{}",
+                file!(),
+                line!()
+            ));
+            return result;
+        }
+    };
+    let Ok(stride) = usize::try_from(frame.info().stride()[0]) else {
+        return result;
+    };
+    let mut histogram = [0_u64; 256];
+    for row in 0..frame.height() as usize {
+        let start = row * stride;
+        let Some(pixels) = plane.get(start..start + frame.width() as usize) else {
+            return result;
+        };
+        for &pixel in pixels {
+            histogram[usize::from(pixel)] += 1;
+        }
+    }
+    let count: u64 = histogram.iter().sum();
+    let mut sum = 0_u64;
+    for (value, count) in histogram.iter().enumerate() {
+        sum += value as u64 * count;
+    }
+    result["luma"] = json!({
+        "sample_count": count,
+        "mean": if count == 0 { 0.0 } else { sum as f64 / count as f64 },
+        "histogram": histogram.as_slice(),
+    });
+    result
+}
+
+#[cfg(test)]
+#[path = "tests/debug_state.test.rs"]
+mod tests;

--- a/rust/src/editor/export.rs
+++ b/rust/src/editor/export.rs
@@ -35,7 +35,7 @@ impl ExportEncoder {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(super) struct ExportOptions {
+pub struct ExportOptions {
     pub width: u32,
     pub height: u32,
     pub frame_rate: FrameRate,

--- a/rust/src/editor/export_gstreamer.rs
+++ b/rust/src/editor/export_gstreamer.rs
@@ -130,6 +130,8 @@ pub fn build_ges_timeline(
     } else {
         ges::Timeline::new_audio_video()
     };
+    #[cfg(target_os = "macos")]
+    timeline.connect_deep_element_added(|_, _, element| configure_timeline_decoder(element));
     let video_caps = gst::Caps::builder("video/x-raw")
         .field("width", options.width.max(2) as i32)
         .field("height", options.height.max(2) as i32)
@@ -149,6 +151,8 @@ pub fn build_ges_timeline(
         track.set_mixing(true);
     }
 
+    let output_scale = (options.width.max(2) as f64 / timeline_data.settings.width.max(2) as f64)
+        .min(options.height.max(2) as f64 / timeline_data.settings.height.max(2) as f64);
     let mut assets: HashMap<Ulid, ges::UriClipAsset> = HashMap::new();
     for timeline_track in timeline_data
         .tracks
@@ -162,64 +166,7 @@ pub fn build_ges_timeline(
         )
     {
         let layer = timeline.append_layer();
-        if audio_only && timeline_track.kind == TrackKind::Text {
-            continue;
-        }
-        if timeline_track.kind == TrackKind::Text {
-            if !timeline_track.visible {
-                continue;
-            }
-            let output_scale = (options.width.max(2) as f64
-                / timeline_data.settings.width.max(2) as f64)
-                .min(options.height.max(2) as f64 / timeline_data.settings.height.max(2) as f64);
-            let mut clips = timeline_data
-                .clips_on_track(timeline_track.id)
-                .collect::<Vec<_>>();
-            clips.sort_by_key(|clip| clip.timeline_start());
-            for clip in clips {
-                let text = clip
-                    .text()
-                    .ok_or_else(|| anyhow!("Media clip {} is on a text track.", clip.id()))?;
-                let overlay = ges::TitleClip::new().ok_or_else(|| {
-                    anyhow!(
-                        "could not create text clip {} at {}:{}",
-                        clip.id(),
-                        file!(),
-                        line!()
-                    )
-                })?;
-                overlay
-                    .set_name(Some(&format!("opencut-clip-{}", clip.id())))
-                    .map_err(|error| anyhow!("could not identify clip {}: {error}", clip.id()))?;
-                let (start, duration) = clip_clock_range(
-                    timeline_data.settings.frame_rate,
-                    clip,
-                    clip.timeline_start(),
-                );
-                if !overlay.set_start(start) {
-                    return Err(anyhow!(
-                        "could not set text clip {} start at {}:{}",
-                        clip.id(),
-                        file!(),
-                        line!()
-                    ));
-                }
-                if !overlay.set_duration(duration) {
-                    return Err(anyhow!(
-                        "could not set text clip {} duration at {}:{}",
-                        clip.id(),
-                        file!(),
-                        line!()
-                    ));
-                }
-                layer.add_clip(&overlay).map_err(|error| {
-                    anyhow!(
-                        "could not add text clip {} to the timeline: {error}",
-                        clip.id()
-                    )
-                })?;
-                configure_text_clip(&overlay, &text.properties, output_scale)?;
-            }
+        if timeline_track.kind == TrackKind::Text && (audio_only || !timeline_track.visible) {
             continue;
         }
         let mut clips = timeline_data
@@ -227,6 +174,15 @@ pub fn build_ges_timeline(
             .collect::<Vec<_>>();
         clips.sort_by_key(|clip| clip.timeline_start());
         for clip in clips {
+            if timeline_track.kind == TrackKind::Text {
+                add_text_clip(
+                    &layer,
+                    timeline_data.settings.frame_rate,
+                    clip,
+                    output_scale,
+                )?;
+                continue;
+            }
             let media = clip
                 .media()
                 .ok_or_else(|| anyhow!("Text clip {} is on a media track.", clip.id()))?;
@@ -405,6 +361,95 @@ fn export_timeline_with_encoder(
     );
     let _ = pipeline.set_state(gst::State::Null);
     result
+}
+
+#[cfg(target_os = "macos")]
+fn configure_timeline_decoder(element: &gst::Element) {
+    // Work around black HEVC frames at GES composition boundaries on VideoToolbox.
+    // Keep decoder selection local to this timeline.
+    if !element
+        .factory()
+        .is_some_and(|factory| factory.name() == "uridecodebin")
+    {
+        return;
+    }
+    element.connect("autoplug-select", false, |values| {
+        let caps = values[2].get::<gst::Caps>().expect("autoplug-select caps");
+        let factory = values[3]
+            .get::<gst::ElementFactory>()
+            .expect("autoplug-select factory");
+        let skip = caps
+            .structure(0)
+            .is_some_and(|structure| structure.name() == "video/x-h265")
+            && matches!(factory.name().as_str(), "vtdec" | "vtdec_hw")
+            && gst::ElementFactory::find("avdec_h265").is_some();
+        let class = gst::glib::EnumClass::with_type(
+            gst::glib::Type::from_name("GstAutoplugSelectResult")
+                .expect("autoplug-select result type"),
+        )
+        .expect("autoplug-select result enum");
+        class.to_value_by_nick(if skip { "skip" } else { "try" })
+    });
+}
+
+fn add_text_clip(
+    layer: &ges::Layer,
+    rate: FrameRate,
+    clip: &Clip,
+    output_scale: f64,
+) -> Result<()> {
+    let text = clip.text().ok_or_else(|| {
+        anyhow!(
+            "Media clip {} is on a text track at {}:{}",
+            clip.id(),
+            file!(),
+            line!()
+        )
+    })?;
+    let overlay = ges::TitleClip::new().ok_or_else(|| {
+        anyhow!(
+            "could not create text clip {} at {}:{}",
+            clip.id(),
+            file!(),
+            line!()
+        )
+    })?;
+    overlay
+        .set_name(Some(&format!("opencut-clip-{}", clip.id())))
+        .map_err(|error| {
+            anyhow!(
+                "could not identify clip {}: {error} at {}:{}",
+                clip.id(),
+                file!(),
+                line!()
+            )
+        })?;
+    let (start, duration) = clip_clock_range(rate, clip, clip.timeline_start());
+    if !overlay.set_start(start) {
+        return Err(anyhow!(
+            "could not set text clip {} start at {}:{}",
+            clip.id(),
+            file!(),
+            line!()
+        ));
+    }
+    if !overlay.set_duration(duration) {
+        return Err(anyhow!(
+            "could not set text clip {} duration at {}:{}",
+            clip.id(),
+            file!(),
+            line!()
+        ));
+    }
+    layer.add_clip(&overlay).map_err(|error| {
+        anyhow!(
+            "could not add text clip {} to the timeline: {error} at {}:{}",
+            clip.id(),
+            file!(),
+            line!()
+        )
+    })?;
+    configure_text_clip(&overlay, &text.properties, output_scale)
 }
 
 fn rounded_i32(value: f64) -> i32 {

--- a/rust/src/editor/export_gstreamer.rs
+++ b/rust/src/editor/export_gstreamer.rs
@@ -347,10 +347,10 @@ pub(super) fn apply_video_transform(
     );
 
     for (name, value) in [
-        ("posx", rounded_i32(plan.visible.left)),
-        ("posy", rounded_i32(plan.visible.top)),
-        ("width", rounded_i32(plan.visible.width).max(1)),
-        ("height", rounded_i32(plan.visible.height).max(1)),
+        ("posx", rounded_i32(plan.visible.origin.x)),
+        ("posy", rounded_i32(plan.visible.origin.y)),
+        ("width", rounded_i32(plan.visible.size.width).max(1)),
+        ("height", rounded_i32(plan.visible.size.height).max(1)),
     ] {
         clip.set_child_property(name, value)
             .map_err(|error| anyhow!("could not apply video {name}: {error}"))?;

--- a/rust/src/editor/mod.rs
+++ b/rust/src/editor/mod.rs
@@ -17,6 +17,7 @@ use std::{
 mod clip_placement;
 mod clip_render_plan;
 mod context_menu;
+mod debug_state;
 mod editing;
 mod editor;
 mod editor_view;

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -58,27 +58,6 @@ pub fn preview_timeline_view(
     let timeline_left = origin_x + TIMELINE_HORIZONTAL_PADDING;
     let volume_track_bottom = origin_y + height - TIMELINE_VOLUME_TRACK_BOTTOM_OFFSET;
     let has_media = !timeline.data.clips.is_empty();
-    let mut clip_cursor_regions = Vec::new();
-    // Rectangles are front-to-back; paint cursor regions back-to-front.
-    for &(clip_id, rect) in clip_rects.iter().rev() {
-        let Some(rect) = clipped_preview_rect(rect, canvas.bounds) else {
-            continue;
-        };
-        clip_cursor_regions.push(
-            div()
-                .absolute()
-                .left(px(rect.origin.x as f32))
-                .top(px(rect.origin.y as f32))
-                .w(px(rect.size.width as f32))
-                .h(px(rect.size.height as f32))
-                .cursor(if timeline.data.clip_locked(clip_id) {
-                    CursorStyle::Arrow
-                } else {
-                    CursorStyle::OpenHand
-                }),
-        );
-    }
-
     let mut resize_handles = Vec::new();
     if let Some(rect) = selected_rect
         && let Some(clip_id) = timeline.interaction.selected_clip_id
@@ -100,11 +79,7 @@ pub fn preview_timeline_view(
                     .bg(rgb(ACCENT))
                     .border_1()
                     .border_color(rgb(0x101012))
-                    .cursor(if horizontal == vertical {
-                        CursorStyle::ResizeUpLeftDownRight
-                    } else {
-                        CursorStyle::ResizeUpRightDownLeft
-                    })
+                    .cursor(CursorStyle::Arrow)
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |editor, event, _, cx| {
@@ -265,7 +240,6 @@ pub fn preview_timeline_view(
                             .border_color(rgb(ACCENT)),
                     )
                 })
-                .children(clip_cursor_regions)
                 .children(resize_handles),
         )
         .child(
@@ -290,7 +264,7 @@ pub fn preview_timeline_view(
                             .h_4()
                             .flex()
                             .items_center()
-                            .cursor(CursorStyle::PointingHand)
+                            .cursor(CursorStyle::Arrow)
                             .child(
                                 div()
                                     .w_full()
@@ -354,7 +328,7 @@ pub fn preview_timeline_view(
                                         .flex()
                                         .items_center()
                                         .justify_center()
-                                        .cursor(CursorStyle::PointingHand)
+                                        .cursor(CursorStyle::Arrow)
                                         .rounded_full()
                                         .hover(|style| style.bg(rgb(SURFACE_HOVER)))
                                         .text_lg()
@@ -461,7 +435,7 @@ pub fn preview_timeline_view(
                                                             ))
                                                             .flex()
                                                             .justify_center()
-                                                            .cursor(CursorStyle::PointingHand)
+                                                            .cursor(CursorStyle::Arrow)
                                                             .child(
                                                                 div()
                                                                     .w(px(5.0))
@@ -518,7 +492,7 @@ pub fn preview_timeline_view(
                                                 .flex()
                                                 .items_center()
                                                 .justify_center()
-                                                .cursor(CursorStyle::PointingHand)
+                                                .cursor(CursorStyle::Arrow)
                                                 .rounded_xl()
                                                 .border_1()
                                                 .border_color(rgb(BORDER))
@@ -560,7 +534,7 @@ pub fn preview_timeline_view(
                                 .child(
                                     div()
                                         .id("editor-timeline-fullscreen")
-                                        .cursor(CursorStyle::PointingHand)
+                                        .cursor(CursorStyle::Arrow)
                                         .rounded_md()
                                         .hover(|style| style.bg(rgb(SURFACE_HOVER)))
                                         .px_3()

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -1,11 +1,11 @@
 use super::*;
 use super::{
-    clip_render_plan::{RenderRect, resolve_visual_clip_render_plan},
+    clip_render_plan::resolve_visual_clip_render_plan,
     timeline_video::{refresh_timeline_video_frame, try_refresh_timeline_video_frame},
 };
 use crate::playback_view::{CONTROL_HEIGHT, format_duration};
 use crate::video::video;
-use gpui::relative;
+use gpui::{point, relative, size};
 
 pub fn preview_timeline_view(
     editor: &Editor,
@@ -28,22 +28,27 @@ pub fn preview_timeline_view(
     let output_left = (f64::from(width) - output_width) * 0.5;
     let output_top = (f64::from(surface_height) - output_height) * 0.5;
     let canvas = TimelinePreviewCanvas {
-        left: output_left,
-        top: output_top,
-        width: output_width,
-        height: output_height,
+        bounds: Bounds::new(
+            point(output_left, output_top),
+            size(output_width, output_height),
+        ),
         project_scale: project_scale.max(f64::EPSILON),
     };
-    let selected_rect = timeline.interaction.selected_clip_id.and_then(|clip_id| {
-        let clip = timeline.data.clip(clip_id)?;
-        let media = clip.media()?;
-        if clip.timeline_start() > timeline.playhead()
-            || timeline.playhead() >= clip.timeline_end(timeline.data.settings.frame_rate)
-        {
-            return None;
+    let clip_rects = timeline_preview_clip_rects(
+        &timeline.data,
+        timeline.video_backend.ges_timeline(),
+        timeline.playhead(),
+        canvas,
+    );
+    let selected_rect = (|| {
+        let selected = timeline.interaction.selected_clip_id?;
+        for &(clip_id, rect) in &clip_rects {
+            if clip_id == selected {
+                return Some(rect);
+            }
         }
-        timeline_preview_clip_rect(&timeline.data, clip, media.video_properties, canvas)
-    });
+        None
+    })();
     let (snap_x, snap_y) = editor
         .preview
         .timeline_drag
@@ -54,52 +59,38 @@ pub fn preview_timeline_view(
     let volume_track_bottom = origin_y + height - TIMELINE_VOLUME_TRACK_BOTTOM_OFFSET;
     let has_media = !timeline.data.clips.is_empty();
     let mut clip_cursor_regions = Vec::new();
-    for track in &timeline.data.tracks {
-        for clip in timeline.data.clips_on_track(track.id) {
-            if clip.timeline_start() > timeline.playhead()
-                || timeline.playhead() >= clip.timeline_end(timeline.data.settings.frame_rate)
-            {
-                continue;
-            }
-            let Some(media) = clip.media() else {
-                continue;
-            };
-            let Some(rect) =
-                timeline_preview_clip_rect(&timeline.data, clip, media.video_properties, canvas)
-            else {
-                continue;
-            };
-            let left = rect.left.max(canvas.left);
-            let top = rect.top.max(canvas.top);
-            let right = (rect.left + rect.width).min(canvas.left + canvas.width);
-            let bottom = (rect.top + rect.height).min(canvas.top + canvas.height);
-            if right <= left || bottom <= top {
-                continue;
-            }
-            clip_cursor_regions.push(
-                div()
-                    .absolute()
-                    .left(px(left as f32))
-                    .top(px(top as f32))
-                    .w(px((right - left) as f32))
-                    .h(px((bottom - top) as f32))
-                    .cursor(if track.locked {
-                        CursorStyle::Arrow
-                    } else {
-                        CursorStyle::OpenHand
-                    }),
-            );
-        }
+    // Rectangles are front-to-back; paint cursor regions back-to-front.
+    for &(clip_id, rect) in clip_rects.iter().rev() {
+        let Some(rect) = clipped_preview_rect(rect, canvas.bounds) else {
+            continue;
+        };
+        clip_cursor_regions.push(
+            div()
+                .absolute()
+                .left(px(rect.origin.x as f32))
+                .top(px(rect.origin.y as f32))
+                .w(px(rect.size.width as f32))
+                .h(px(rect.size.height as f32))
+                .cursor(if timeline.data.clip_locked(clip_id) {
+                    CursorStyle::Arrow
+                } else {
+                    CursorStyle::OpenHand
+                }),
+        );
     }
 
     let mut resize_handles = Vec::new();
     if let Some(rect) = selected_rect
         && let Some(clip_id) = timeline.interaction.selected_clip_id
+        && timeline
+            .data
+            .clip(clip_id)
+            .is_some_and(|clip| clip.media().is_some())
         && !timeline.data.clip_locked(clip_id)
     {
         for (horizontal, vertical) in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
-            let x = rect.left + (horizontal + 1.0) * rect.width * 0.5;
-            let y = rect.top + (vertical + 1.0) * rect.height * 0.5;
+            let x = rect.origin.x + (horizontal + 1.0) * rect.size.width * 0.5;
+            let y = rect.origin.y + (vertical + 1.0) * rect.size.height * 0.5;
             resize_handles.push(
                 div()
                     .absolute()
@@ -244,9 +235,9 @@ pub fn preview_timeline_view(
                         div()
                             .absolute()
                             .left(px((guide - 0.5) as f32))
-                            .top(px(canvas.top as f32))
+                            .top(px(canvas.bounds.origin.y as f32))
                             .w(px(1.0))
-                            .h(px(canvas.height as f32))
+                            .h(px(canvas.bounds.size.height as f32))
                             .bg(rgb(ACCENT)),
                     )
                 })
@@ -254,9 +245,9 @@ pub fn preview_timeline_view(
                     this.child(
                         div()
                             .absolute()
-                            .left(px(canvas.left as f32))
+                            .left(px(canvas.bounds.origin.x as f32))
                             .top(px((guide - 0.5) as f32))
-                            .w(px(canvas.width as f32))
+                            .w(px(canvas.bounds.size.width as f32))
                             .h(px(1.0))
                             .bg(rgb(ACCENT)),
                     )
@@ -266,10 +257,10 @@ pub fn preview_timeline_view(
                         div()
                             .id("editor-timeline-preview-selection")
                             .absolute()
-                            .left(px(rect.left as f32))
-                            .top(px(rect.top as f32))
-                            .w(px(rect.width.max(1.0) as f32))
-                            .h(px(rect.height.max(1.0) as f32))
+                            .left(px(rect.origin.x as f32))
+                            .top(px(rect.origin.y as f32))
+                            .w(px(rect.size.width.max(1.0) as f32))
+                            .h(px(rect.size.height.max(1.0) as f32))
                             .border_1()
                             .border_color(rgb(ACCENT)),
                     )
@@ -594,10 +585,7 @@ const TIMELINE_TRANSFORM_UPDATE_INTERVAL: Duration = Duration::from_millis(16);
 
 #[derive(Clone, Copy, Debug)]
 struct TimelinePreviewCanvas {
-    left: f64,
-    top: f64,
-    width: f64,
-    height: f64,
+    bounds: Bounds<f64>,
     project_scale: f64,
 }
 
@@ -618,7 +606,7 @@ pub(super) struct TimelinePreviewDrag {
 enum PreviewDragMode {
     Move,
     Resize {
-        rect: RenderRect,
+        rect: Bounds<f64>,
         horizontal: f64,
         vertical: f64,
     },
@@ -626,42 +614,43 @@ enum PreviewDragMode {
 
 fn resized_preview_properties(
     original: VideoClipProperties,
-    rect: RenderRect,
+    rect: Bounds<f64>,
     corner: (f64, f64),
     delta: (f64, f64),
     project_scale: f64,
 ) -> VideoClipProperties {
-    let diagonal_squared = rect.width * rect.width + rect.height * rect.height;
+    let diagonal_squared = rect.size.width * rect.size.width + rect.size.height * rect.size.height;
     if diagonal_squared <= f64::EPSILON || original.scale <= f64::EPSILON {
         return original;
     }
     let factor = 1.0
-        + (delta.0 * corner.0 * rect.width + delta.1 * corner.1 * rect.height) / diagonal_squared;
+        + (delta.0 * corner.0 * rect.size.width + delta.1 * corner.1 * rect.size.height)
+            / diagonal_squared;
     let scale = (original.scale * factor).clamp(0.01, 100.0);
     let factor = scale / original.scale;
     VideoClipProperties {
         position_x: original.position_x
-            + corner.0 * rect.width * (factor - 1.0) * 0.5 / project_scale,
+            + corner.0 * rect.size.width * (factor - 1.0) * 0.5 / project_scale,
         position_y: original.position_y
-            + corner.1 * rect.height * (factor - 1.0) * 0.5 / project_scale,
+            + corner.1 * rect.size.height * (factor - 1.0) * 0.5 / project_scale,
         scale,
     }
 }
 
 fn snap_preview_resize(
     properties: VideoClipProperties,
-    rect: RenderRect,
+    rect: Bounds<f64>,
     corner: (f64, f64),
     project_scale: f64,
     horizontal_guides: &[f64],
     vertical_guides: &[f64],
 ) -> (VideoClipProperties, Option<f64>, Option<f64>) {
-    let fixed_x = rect.left + (1.0 - corner.0) * rect.width * 0.5;
-    let fixed_y = rect.top + (1.0 - corner.1) * rect.height * 0.5;
+    let fixed_x = rect.origin.x + (1.0 - corner.0) * rect.size.width * 0.5;
+    let fixed_y = rect.origin.y + (1.0 - corner.1) * rect.size.height * 0.5;
     let mut best_factor: Option<f64> = None;
     for (fixed, span, guides) in [
-        (fixed_x, corner.0 * rect.width, horizontal_guides),
-        (fixed_y, corner.1 * rect.height, vertical_guides),
+        (fixed_x, corner.0 * rect.size.width, horizontal_guides),
+        (fixed_y, corner.1 * rect.size.height, vertical_guides),
     ] {
         if span.abs() <= f64::EPSILON {
             continue;
@@ -689,21 +678,22 @@ fn snap_preview_resize(
     };
     let snapped = VideoClipProperties {
         position_x: properties.position_x
-            + corner.0 * rect.width * (factor - 1.0) * 0.5 / project_scale,
+            + corner.0 * rect.size.width * (factor - 1.0) * 0.5 / project_scale,
         position_y: properties.position_y
-            + corner.1 * rect.height * (factor - 1.0) * 0.5 / project_scale,
+            + corner.1 * rect.size.height * (factor - 1.0) * 0.5 / project_scale,
         scale: properties.scale * factor,
     };
     let mut snap_x = None;
     let mut snap_y = None;
     for fraction in [1.0, 0.5] {
         for &guide in horizontal_guides {
-            if (fixed_x + corner.0 * rect.width * factor * fraction - guide).abs() < 0.000001 {
+            if (fixed_x + corner.0 * rect.size.width * factor * fraction - guide).abs() < 0.000001 {
                 snap_x = Some(guide);
             }
         }
         for &guide in vertical_guides {
-            if (fixed_y + corner.1 * rect.height * factor * fraction - guide).abs() < 0.000001 {
+            if (fixed_y + corner.1 * rect.size.height * factor * fraction - guide).abs() < 0.000001
+            {
                 snap_y = Some(guide);
             }
         }
@@ -727,12 +717,130 @@ fn nearest_canvas_snap(clip_anchors: [f64; 3], canvas_guides: &[f64]) -> Option<
     nearest
 }
 
+fn timeline_preview_clip_rects(
+    timeline: &TimelineSerialization,
+    ges: &gstreamer_editing_services::Timeline,
+    position: TimelineTime,
+    canvas: TimelinePreviewCanvas,
+) -> Vec<(Ulid, Bounds<f64>)> {
+    let mut rects = Vec::new();
+    // GES assigns lower (frontmost) priorities to text tracks first, then media.
+    for kind in [TrackKind::Text, TrackKind::Video] {
+        for track in &timeline.tracks {
+            if track.kind != kind || !track.visible {
+                continue;
+            }
+            for clip in timeline.clips_on_track(track.id) {
+                if position < clip.timeline_start()
+                    || position >= clip.timeline_end(timeline.settings.frame_rate)
+                {
+                    continue;
+                }
+                let rect = match clip {
+                    Clip::Video(media) | Clip::Audio(media) => {
+                        timeline_preview_clip_rect(timeline, clip, media.video_properties, canvas)
+                    }
+                    Clip::Text(text) => {
+                        if text.properties.text.trim().is_empty()
+                            || text.properties.color >> 24 == 0
+                        {
+                            continue;
+                        }
+                        timeline_preview_text_rect(ges, text.id, canvas)
+                    }
+                };
+                if let Some(rect) = rect {
+                    rects.push((clip.id(), rect));
+                }
+            }
+        }
+    }
+    rects
+}
+
+fn timeline_preview_text_rect(
+    ges: &gstreamer_editing_services::Timeline,
+    clip_id: Ulid,
+    canvas: TimelinePreviewCanvas,
+) -> Option<Bounds<f64>> {
+    use gstreamer_editing_services::prelude::*;
+
+    let name = format!("opencut-clip-{clip_id}");
+    for layer in ges.layers() {
+        for clip in layer.clips() {
+            if clip.name().as_deref() == Some(name.as_str()) {
+                let (overlay, _) = clip.lookup_child("font-desc")?;
+                return rendered_text_rect(&overlay, canvas);
+            }
+        }
+    }
+    None
+}
+
+fn rendered_text_rect(
+    overlay: &gstreamer::glib::Object,
+    canvas: TimelinePreviewCanvas,
+) -> Option<Bounds<f64>> {
+    use gstreamer::prelude::*;
+
+    // Read the actual Pango rendering, including multiline layout and font fallback.
+    // Properties have placeholder defaults before the renderer negotiates a frame.
+    let element = overlay.downcast_ref::<gstreamer::Element>()?;
+    element.static_pad("video_sink")?.current_caps()?;
+    for name in ["text-x", "text-y", "text-width", "text-height"] {
+        overlay.find_property(name)?;
+    }
+    let width = overlay.property::<u32>("text-width");
+    let height = overlay.property::<u32>("text-height");
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some(Bounds::new(
+        point(
+            canvas.bounds.origin.x
+                + f64::from(overlay.property::<i32>("text-x")) * canvas.project_scale,
+            canvas.bounds.origin.y
+                + f64::from(overlay.property::<i32>("text-y")) * canvas.project_scale,
+        ),
+        size(
+            f64::from(width) * canvas.project_scale,
+            f64::from(height) * canvas.project_scale,
+        ),
+    ))
+}
+
+fn clipped_preview_rect(rect: Bounds<f64>, canvas: Bounds<f64>) -> Option<Bounds<f64>> {
+    let clipped = rect.intersect(&canvas);
+    if clipped.size.width <= 0.0 || clipped.size.height <= 0.0 {
+        return None;
+    }
+    Some(clipped)
+}
+
+fn hit_preview_clip(
+    rects: &[(Ulid, Bounds<f64>)],
+    canvas: TimelinePreviewCanvas,
+    x: f64,
+    y: f64,
+) -> Option<Ulid> {
+    for &(clip_id, rect) in rects {
+        let Some(rect) = clipped_preview_rect(rect, canvas.bounds) else {
+            continue;
+        };
+        // Preserve inclusive right/bottom edges; Bounds::contains excludes them.
+        if x >= rect.origin.x && x <= rect.right() && y >= rect.origin.y && y <= rect.bottom() {
+            return Some(clip_id);
+        }
+    }
+    None
+}
+
 fn timeline_preview_clip_rect(
     timeline: &TimelineSerialization,
     clip: &Clip,
     properties: VideoClipProperties,
     canvas: TimelinePreviewCanvas,
-) -> Option<RenderRect> {
+) -> Option<Bounds<f64>> {
     let clip = clip.media()?;
     let track = timeline.track(clip.track_id)?;
     if track.kind != TrackKind::Video || !track.visible {
@@ -748,16 +856,11 @@ fn timeline_preview_clip_rect(
         asset.height,
         timeline.settings.width,
         timeline.settings.height,
-        canvas.width,
-        canvas.height,
+        canvas.bounds.size.width,
+        canvas.bounds.size.height,
     )
     .visible;
-    Some(RenderRect {
-        left: canvas.left + visible.left,
-        top: canvas.top + visible.top,
-        width: visible.width,
-        height: visible.height,
-    })
+    Some(visible + canvas.bounds.origin)
 }
 
 impl Editor {
@@ -779,28 +882,13 @@ impl Editor {
         let clip_id = if matches!(mode, PreviewDragMode::Resize { .. }) {
             timeline.interaction.selected_clip_id
         } else {
-            timeline.data.tracks.iter().rev().find_map(|track| {
-                timeline.data.clips_on_track(track.id).find_map(|clip| {
-                    let media = clip.media()?;
-                    if clip.timeline_start() > timeline.playhead()
-                        || timeline.playhead()
-                            >= clip.timeline_end(timeline.data.settings.frame_rate)
-                    {
-                        return None;
-                    }
-                    let rect = timeline_preview_clip_rect(
-                        &timeline.data,
-                        clip,
-                        media.video_properties,
-                        canvas,
-                    )?;
-                    (f64::from(pointer_x) >= rect.left
-                        && f64::from(pointer_x) <= rect.left + rect.width
-                        && f64::from(pointer_y) >= rect.top
-                        && f64::from(pointer_y) <= rect.top + rect.height)
-                        .then_some(clip.id())
-                })
-            })
+            let rects = timeline_preview_clip_rects(
+                &timeline.data,
+                timeline.video_backend.ges_timeline(),
+                timeline.playhead(),
+                canvas,
+            );
+            hit_preview_clip(&rects, canvas, f64::from(pointer_x), f64::from(pointer_y))
         };
         self.select_only_clip(clip_id);
         let Some(clip_id) = clip_id else {
@@ -822,6 +910,10 @@ impl Editor {
             return;
         };
         let Some(clip) = clip.media() else {
+            // Text selection is supported before text movement is implemented.
+            self.preview.timeline_drag = None;
+            cx.notify();
+            cx.stop_propagation();
             return;
         };
         self.preview.timeline_drag = Some(TimelinePreviewDrag {
@@ -889,14 +981,14 @@ impl Editor {
         drag.snap_y = None;
         if timeline.interaction.snapping_enabled {
             let mut horizontal_guides = vec![
-                drag.canvas.left,
-                drag.canvas.left + drag.canvas.width * 0.5,
-                drag.canvas.left + drag.canvas.width,
+                drag.canvas.bounds.origin.x,
+                drag.canvas.bounds.origin.x + drag.canvas.bounds.size.width * 0.5,
+                drag.canvas.bounds.origin.x + drag.canvas.bounds.size.width,
             ];
             let mut vertical_guides = vec![
-                drag.canvas.top,
-                drag.canvas.top + drag.canvas.height * 0.5,
-                drag.canvas.top + drag.canvas.height,
+                drag.canvas.bounds.origin.y,
+                drag.canvas.bounds.origin.y + drag.canvas.bounds.size.height * 0.5,
+                drag.canvas.bounds.origin.y + drag.canvas.bounds.size.height,
             ];
             for clip in &timeline.data.clips {
                 if clip.id() == drag.clip_id
@@ -917,14 +1009,14 @@ impl Editor {
                     continue;
                 };
                 horizontal_guides.extend([
-                    other.left,
-                    other.left + other.width * 0.5,
-                    other.left + other.width,
+                    other.origin.x,
+                    other.origin.x + other.size.width * 0.5,
+                    other.origin.x + other.size.width,
                 ]);
                 vertical_guides.extend([
-                    other.top,
-                    other.top + other.height * 0.5,
-                    other.top + other.height,
+                    other.origin.y,
+                    other.origin.y + other.size.height * 0.5,
+                    other.origin.y + other.size.height,
                 ]);
             }
             if let Some(rect) = timeline_preview_clip_rect(
@@ -937,9 +1029,9 @@ impl Editor {
                     PreviewDragMode::Move => {
                         if let Some((delta, guide)) = nearest_canvas_snap(
                             [
-                                rect.left + rect.width * 0.5,
-                                rect.left,
-                                rect.left + rect.width,
+                                rect.origin.x + rect.size.width * 0.5,
+                                rect.origin.x,
+                                rect.right(),
                             ],
                             &horizontal_guides,
                         ) {
@@ -948,9 +1040,9 @@ impl Editor {
                         }
                         if let Some((delta, guide)) = nearest_canvas_snap(
                             [
-                                rect.top + rect.height * 0.5,
-                                rect.top,
-                                rect.top + rect.height,
+                                rect.origin.y + rect.size.height * 0.5,
+                                rect.origin.y,
+                                rect.bottom(),
                             ],
                             &vertical_guides,
                         ) {

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -58,6 +58,8 @@ pub fn preview_timeline_view(
     let timeline_left = origin_x + TIMELINE_HORIZONTAL_PADDING;
     let volume_track_bottom = origin_y + height - TIMELINE_VOLUME_TRACK_BOTTOM_OFFSET;
     let has_media = !timeline.data.clips.is_empty();
+    let selected_clip_id = timeline.interaction.selected_clip_id;
+    let show_hover = editor.preview.timeline_drag.is_none() && !editor.preview.volume_control_open;
     let mut resize_handles = Vec::new();
     if let Some(rect) = selected_rect
         && let Some(clip_id) = timeline.interaction.selected_clip_id
@@ -184,6 +186,7 @@ pub fn preview_timeline_view(
                 .overflow_hidden()
                 .bg(rgb(0x000000))
                 .cursor(CursorStyle::Arrow)
+                .on_hover(cx.listener(|_, _, _, cx| cx.notify()))
                 .when(has_media, |this| {
                     this.on_mouse_down(
                         MouseButton::Left,
@@ -204,6 +207,42 @@ pub fn preview_timeline_view(
                         .id("editor-timeline-video")
                         .size(px(width), px(surface_height))
                         .into_any_element(),
+                )
+                .child(
+                    gpui::canvas(
+                        move |bounds, window, _| {
+                            if !show_hover {
+                                return None;
+                            }
+                            let pointer = window.mouse_position() - bounds.origin;
+                            let clip_id = hit_preview_clip(
+                                &clip_rects,
+                                &canvas,
+                                f64::from(f32::from(pointer.x)),
+                                f64::from(f32::from(pointer.y)),
+                            )?;
+                            // Keep the selected outline gold, even when hovered.
+                            if Some(clip_id) == selected_clip_id {
+                                return None;
+                            }
+                            for &(id, rect) in &clip_rects {
+                                if id == clip_id {
+                                    return Some(Bounds::new(
+                                        bounds.origin + point(px(rect.origin.x as f32), px(rect.origin.y as f32)),
+                                        size(px(rect.size.width as f32), px(rect.size.height as f32)),
+                                    ));
+                                }
+                            }
+                            None
+                        },
+                        |_, rect, window, _| {
+                            if let Some(rect) = rect {
+                                window.paint_quad(gpui::outline(rect, rgb(0x75bfff), gpui::BorderStyle::Solid));
+                            }
+                        },
+                    )
+                    .absolute()
+                    .size_full(),
                 )
                 .when_some(snap_x, |this, guide| {
                     this.child(
@@ -1127,6 +1166,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         if !event.dragging() {
+            cx.notify();
             return;
         }
         if self.update_timeline_preview_clip_drag(event, cx) {

--- a/rust/src/editor/preview_timeline.rs
+++ b/rust/src/editor/preview_timeline.rs
@@ -38,7 +38,7 @@ pub fn preview_timeline_view(
         &timeline.data,
         timeline.video_backend.ges_timeline(),
         timeline.playhead(),
-        canvas,
+        &canvas,
     );
     let selected_rect = (|| {
         let selected = timeline.interaction.selected_clip_id?;
@@ -112,7 +112,7 @@ pub fn preview_timeline_view(
                                 event,
                                 origin_x,
                                 origin_y,
-                                canvas,
+                                &canvas,
                                 PreviewDragMode::Resize {
                                     rect,
                                     horizontal,
@@ -217,7 +217,7 @@ pub fn preview_timeline_view(
                                 event,
                                 origin_x,
                                 origin_y,
-                                canvas,
+                                &canvas,
                                 PreviewDragMode::Move,
                                 cx,
                             );
@@ -721,7 +721,7 @@ fn timeline_preview_clip_rects(
     timeline: &TimelineSerialization,
     ges: &gstreamer_editing_services::Timeline,
     position: TimelineTime,
-    canvas: TimelinePreviewCanvas,
+    canvas: &TimelinePreviewCanvas,
 ) -> Vec<(Ulid, Bounds<f64>)> {
     let mut rects = Vec::new();
     // GES assigns lower (frontmost) priorities to text tracks first, then media.
@@ -761,7 +761,7 @@ fn timeline_preview_clip_rects(
 fn timeline_preview_text_rect(
     ges: &gstreamer_editing_services::Timeline,
     clip_id: Ulid,
-    canvas: TimelinePreviewCanvas,
+    canvas: &TimelinePreviewCanvas,
 ) -> Option<Bounds<f64>> {
     use gstreamer_editing_services::prelude::*;
 
@@ -779,7 +779,7 @@ fn timeline_preview_text_rect(
 
 fn rendered_text_rect(
     overlay: &gstreamer::glib::Object,
-    canvas: TimelinePreviewCanvas,
+    canvas: &TimelinePreviewCanvas,
 ) -> Option<Bounds<f64>> {
     use gstreamer::prelude::*;
 
@@ -819,7 +819,7 @@ fn clipped_preview_rect(rect: Bounds<f64>, canvas: Bounds<f64>) -> Option<Bounds
 
 fn hit_preview_clip(
     rects: &[(Ulid, Bounds<f64>)],
-    canvas: TimelinePreviewCanvas,
+    canvas: &TimelinePreviewCanvas,
     x: f64,
     y: f64,
 ) -> Option<Ulid> {
@@ -839,7 +839,7 @@ fn timeline_preview_clip_rect(
     timeline: &TimelineSerialization,
     clip: &Clip,
     properties: VideoClipProperties,
-    canvas: TimelinePreviewCanvas,
+    canvas: &TimelinePreviewCanvas,
 ) -> Option<Bounds<f64>> {
     let clip = clip.media()?;
     let track = timeline.track(clip.track_id)?;
@@ -869,7 +869,7 @@ impl Editor {
         event: &MouseDownEvent,
         surface_left: f32,
         surface_top: f32,
-        canvas: TimelinePreviewCanvas,
+        canvas: &TimelinePreviewCanvas,
         mode: PreviewDragMode,
         cx: &mut Context<Self>,
     ) {
@@ -922,7 +922,7 @@ impl Editor {
             pointer_y: f32::from(event.position.y),
             properties: clip.video_properties,
             mode,
-            canvas,
+            canvas: *canvas,
             snap_x: None,
             snap_y: None,
 
@@ -1004,7 +1004,7 @@ impl Editor {
                     &timeline.data,
                     clip,
                     media.video_properties,
-                    drag.canvas,
+                    &drag.canvas,
                 ) else {
                     continue;
                 };
@@ -1023,7 +1023,7 @@ impl Editor {
                 &timeline.data,
                 &timeline.data.clips[index],
                 properties,
-                drag.canvas,
+                &drag.canvas,
             ) {
                 match drag.mode {
                     PreviewDragMode::Move => {

--- a/rust/src/editor/tests/clip_render_plan.test.rs
+++ b/rust/src/editor/tests/clip_render_plan.test.rs
@@ -16,10 +16,10 @@ fn resolves_visual_geometry_in_target_pixels() {
         1080.0,
     );
 
-    assert_eq!(plan.visible.left, 600.0);
-    assert_eq!(plan.visible.top, 210.0);
-    assert_eq!(plan.visible.width, 960.0);
-    assert_eq!(plan.visible.height, 540.0);
+    assert_eq!(plan.visible.origin.x, 600.0);
+    assert_eq!(plan.visible.origin.y, 210.0);
+    assert_eq!(plan.visible.size.width, 960.0);
+    assert_eq!(plan.visible.size.height, 540.0);
 }
 
 #[test]

--- a/rust/src/editor/tests/debug_state.test.rs
+++ b/rust/src/editor/tests/debug_state.test.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+#[test]
+fn frame_dump_measures_visible_luma_without_including_row_padding() {
+    gst::init().unwrap();
+    let info = VideoInfo::builder(gstreamer_video::VideoFormat::Nv12, 2, 2)
+        .build()
+        .unwrap();
+    let mut buffer = gst::Buffer::with_size(info.size()).unwrap();
+    {
+        let buffer = buffer.get_mut().unwrap();
+        buffer.set_pts(gst::ClockTime::from_seconds(1));
+        let mut pixels = buffer.map_writable().unwrap();
+        pixels.fill(255);
+        let stride = info.stride()[0] as usize;
+        for row in 0..2 {
+            pixels[row * stride..row * stride + 2].fill(16);
+        }
+    }
+    let sample = gst::Sample::builder()
+        .buffer(&buffer)
+        .caps(&info.to_caps().unwrap())
+        .build();
+    let report = frame_snapshot(&sample);
+    assert_eq!(report["pts_ns"], 1_000_000_000_u64);
+    assert_eq!(report["luma"]["sample_count"], 4);
+    assert_eq!(report["luma"]["mean"], 16.0);
+    assert_eq!(report["luma"]["histogram"][16], 4);
+    assert_eq!(report["luma"]["histogram"][255], 0);
+}
+
+#[test]
+fn frame_dump_handles_missing_frame_metadata() {
+    gst::init().unwrap();
+    let sample = gst::Sample::builder().build();
+    let report = frame_snapshot(&sample);
+    assert_eq!(report["present"], true);
+    assert_eq!(report["caps"], Value::Null);
+}
+
+#[test]
+fn object_dump_excludes_unlisted_file_locations() {
+    gst::init().unwrap();
+    let source = gst::ElementFactory::make("filesrc")
+        .property("location", "/private/test-token-must-not-be-copied")
+        .build()
+        .unwrap();
+    let report = object_properties(source.upcast_ref());
+    assert!(!report.to_string().contains("test-token"));
+    assert!(report.get("location").is_none());
+}

--- a/rust/src/editor/tests/editing.test.rs
+++ b/rust/src/editor/tests/editing.test.rs
@@ -255,7 +255,6 @@ fn select_all_excludes_clips_on_locked_tracks() {
 fn moves_ges_clip_without_rebuilding_timeline() {
     use gstreamer_editing_services::prelude::*;
 
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(3);
     let clip_id = ulid(10);
@@ -320,7 +319,6 @@ fn moves_ges_clip_without_rebuilding_timeline() {
 fn moves_adjacent_ges_clips_together_without_transient_overlap() {
     use gstreamer_editing_services::prelude::*;
 
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(3);
     let first_clip_id = ulid(10);
@@ -397,7 +395,6 @@ fn moves_adjacent_ges_clips_together_without_transient_overlap() {
 fn moves_adjacent_ges_clips_beyond_timeline_end_without_parking_overlap() {
     use gstreamer_editing_services::prelude::*;
 
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(2);
     let first_clip_id = ulid(10);
@@ -479,7 +476,6 @@ fn moves_adjacent_ges_clips_beyond_timeline_end_without_parking_overlap() {
 fn removes_ges_clip_and_ripples_surviving_clips() {
     use gstreamer_editing_services::prelude::*;
 
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(3);
     let removed_clip_id = ulid(10);
@@ -554,7 +550,6 @@ fn removes_ges_clip_and_ripples_surviving_clips() {
 
 #[test]
 fn splits_ges_clip_with_one_edit_action() {
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(3);
     let original_clip_id = ulid(10);
@@ -614,7 +609,6 @@ fn splits_ges_clip_with_one_edit_action() {
 
 #[test]
 fn detects_timeline_and_ges_data_divergence() {
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let track_id = ulid(3);
     let clip_id = ulid(10);
@@ -668,7 +662,6 @@ fn detects_timeline_and_ges_data_divergence() {
 
 #[test]
 fn updates_video_transform_without_rebuilding_ges_clip() {
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     gstreamer_editing_services::init().unwrap();
     let mut project = TimelineSerialization::with_test_tracks();
     project.settings.width = 1920;

--- a/rust/src/editor/tests/editing.test.rs
+++ b/rust/src/editor/tests/editing.test.rs
@@ -281,6 +281,7 @@ fn moves_ges_clip_without_rebuilding_timeline() {
         &project,
         Path::new(env!("CARGO_MANIFEST_DIR")),
         export::ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let start = TimelineTime::from_frames(45);
@@ -355,6 +356,7 @@ fn moves_adjacent_ges_clips_together_without_transient_overlap() {
         &project,
         Path::new(env!("CARGO_MANIFEST_DIR")),
         export::ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let placements = [
@@ -513,6 +515,7 @@ fn removes_ges_clip_and_ripples_surviving_clips() {
         &project,
         Path::new(env!("CARGO_MANIFEST_DIR")),
         export::ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let mut runtime =
@@ -578,6 +581,7 @@ fn splits_ges_clip_with_one_edit_action() {
         &project,
         Path::new(env!("CARGO_MANIFEST_DIR")),
         export::ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let mut runtime =
@@ -636,6 +640,7 @@ fn detects_timeline_and_ges_data_divergence() {
         &project,
         Path::new(env!("CARGO_MANIFEST_DIR")),
         export::ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let mut runtime =

--- a/rust/src/editor/tests/export_gstreamer.test.rs
+++ b/rust/src/editor/tests/export_gstreamer.test.rs
@@ -308,6 +308,7 @@ fn creates_gstreamer_timeline_from_real_media() {
         &project,
         project_root,
         ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let layers = timeline.layers();
@@ -387,6 +388,7 @@ fn adds_text_clips_as_independent_ges_titles() {
         &project,
         project_root,
         ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let layers = timeline.layers();
@@ -518,6 +520,7 @@ fn hidden_and_muted_tracks_keep_their_duration_as_black_video() {
         &project,
         project_root,
         ExportOptions::from_timeline(&project),
+        false,
     )
     .unwrap();
     let expected_duration = clock_time(project.duration(project.content_duration()));

--- a/rust/src/editor/tests/export_gstreamer.test.rs
+++ b/rust/src/editor/tests/export_gstreamer.test.rs
@@ -6,7 +6,7 @@ use super::*;
 use super::super::{
     media_probe::probe_video,
     model::MediaAsset,
-    tests::{lock_gstreamer_test, ulid},
+    tests::ulid,
     timeline::TimelineTime,
     timeline_clip::{
         AudioClipProperties, TextClip, TextClipProperties, VideoClip, VideoClipProperties,
@@ -33,7 +33,6 @@ fn exports_videotoolbox() {
 }
 
 pub(super) fn export_mini_fixture(encoder: ExportEncoder, output_name: &str) {
-    let _gstreamer_test = lock_gstreamer_test();
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("data/tests/mini测试");
     let output = project_root.join(output_name);
     let mut source_paths = std::fs::read_dir(&project_root)
@@ -157,7 +156,6 @@ fn hidden_video_track_can_still_export_audio() {
 
 #[test]
 fn applies_the_requested_bitrate_to_x264() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let pipeline = ges::Pipeline::new();
     configure_export_elements(&pipeline, 12_345_000);
@@ -168,7 +166,6 @@ fn applies_the_requested_bitrate_to_x264() {
 
 #[test]
 fn configures_aac_encoders_for_export() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let pipeline = ges::Pipeline::new();
     configure_export_elements(&pipeline, 12_345_000);
@@ -189,7 +186,6 @@ fn configures_aac_encoders_for_export() {
 
 #[test]
 fn selects_platform_aac_encoder_without_changing_audio_rank() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let expected = if cfg!(target_os = "macos") {
         "atenc"
@@ -232,7 +228,6 @@ fn selects_platform_aac_encoder_without_changing_audio_rank() {
 #[cfg(target_os = "macos")]
 #[test]
 fn configures_videotoolbox_for_mp4_timeline_export() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let Some(factory) = gst::ElementFactory::find("vtenc_h264_hw") else {
         return;
@@ -247,7 +242,6 @@ fn configures_videotoolbox_for_mp4_timeline_export() {
 
 #[test]
 fn enables_automatic_threading_for_video_conversion_and_scaling() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let pipeline = ges::Pipeline::new();
     configure_export_elements(&pipeline, 12_345_000);
@@ -265,7 +259,6 @@ fn enables_automatic_threading_for_video_conversion_and_scaling() {
 
 #[test]
 fn creates_gstreamer_timeline_from_real_media() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut project = TimelineSerialization::with_test_tracks();
@@ -355,7 +348,6 @@ fn creates_gstreamer_timeline_from_real_media() {
 
 #[test]
 fn adds_text_clips_as_independent_ges_titles() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut project = TimelineSerialization::with_test_tracks();
@@ -479,7 +471,6 @@ fn adds_text_clips_as_independent_ges_titles() {
 
 #[test]
 fn hidden_and_muted_tracks_keep_their_duration_as_black_video() {
-    let _gstreamer_test = lock_gstreamer_test();
     ges::init().unwrap();
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut project = TimelineSerialization::with_test_tracks();
@@ -542,7 +533,6 @@ fn hidden_and_muted_tracks_keep_their_duration_as_black_video() {
 
 #[test]
 fn exports_real_media_with_audio() {
-    let _gstreamer_test = lock_gstreamer_test();
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut project = TimelineSerialization::with_test_tracks();
     project.settings.width = 320;
@@ -593,7 +583,6 @@ fn exports_real_media_with_audio() {
 
 #[test]
 fn exports_an_image_only_timeline() {
-    let _gstreamer_test = lock_gstreamer_test();
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()

--- a/rust/src/editor/tests/mod.test.rs
+++ b/rust/src/editor/tests/mod.test.rs
@@ -3,11 +3,6 @@ pub trait TimelineTestExt: Sized {
 }
 use super::*;
 
-pub(super) fn lock_gstreamer_test() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().unwrap_or_else(|error| error.into_inner())
-}
-
 pub(super) fn ulid(value: u64) -> Ulid {
     Ulid::from(u128::from(value))
 }

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -157,3 +157,170 @@ fn preview_does_not_snap_five_pixels_away() {
         (properties, None, None)
     );
 }
+
+#[test]
+fn hit_testing_uses_frontmost_rectangle_and_excludes_letterboxing() {
+    use super::{RenderRect, TimelinePreviewCanvas, hit_preview_clip};
+    let canvas = TimelinePreviewCanvas {
+        left: 100.0,
+        top: 50.0,
+        width: 400.0,
+        height: 200.0,
+        project_scale: 0.5,
+    };
+    let front = super::Ulid::from(1_u128);
+    let back = super::Ulid::from(2_u128);
+    let rects = [
+        (
+            front,
+            RenderRect {
+                left: 120.0,
+                top: 60.0,
+                width: 80.0,
+                height: 30.0,
+            },
+        ),
+        (
+            back,
+            RenderRect {
+                left: 0.0,
+                top: 0.0,
+                width: 600.0,
+                height: 400.0,
+            },
+        ),
+    ];
+    assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 70.0), Some(front));
+    assert_eq!(hit_preview_clip(&rects, canvas, 300.0, 150.0), Some(back));
+    assert_eq!(hit_preview_clip(&rects, canvas, 30.0, 70.0), None);
+    assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 20.0), None);
+    assert_eq!(hit_preview_clip(&[], canvas, 140.0, 70.0), None);
+}
+
+#[test]
+fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
+    use super::{TimelinePreviewCanvas, rendered_text_rect};
+    use gst::prelude::*;
+    use gstreamer as gst;
+    let _guard = crate::editor::tests::lock_gstreamer_test();
+    gst::init().unwrap();
+    for text in ["Title", "Two\nlines", "你好 世界", ""] {
+        let pipeline = gst::parse::launch(
+            "videotestsrc pattern=black num-buffers=1 ! video/x-raw,width=640,height=360 ! textoverlay name=title auto-resize=false font-desc=\"Sans 32px\" ! fakesink",
+        ).unwrap().downcast::<gst::Pipeline>().unwrap();
+        let overlay = pipeline.by_name("title").unwrap();
+        overlay.set_property("text", text);
+        let canvas = TimelinePreviewCanvas {
+            left: 70.0,
+            top: 20.0,
+            width: 320.0,
+            height: 180.0,
+            project_scale: 0.5,
+        };
+        assert!(rendered_text_rect(overlay.upcast_ref(), canvas).is_none());
+        pipeline.set_state(gst::State::Paused).unwrap();
+        let ready = pipeline.state(gst::ClockTime::from_seconds(5));
+        let rect = rendered_text_rect(overlay.upcast_ref(), canvas);
+        let x = overlay.property::<i32>("text-x");
+        let y = overlay.property::<i32>("text-y");
+        let width = overlay.property::<u32>("text-width");
+        let height = overlay.property::<u32>("text-height");
+        pipeline.set_state(gst::State::Null).unwrap();
+        ready.0.unwrap();
+        assert_eq!(ready.1, gst::State::Paused);
+        if text.is_empty() {
+            continue;
+        }
+        let rect = rect.expect("rendered text has bounds");
+        assert_eq!(rect.left, 70.0 + f64::from(x) * 0.5);
+        assert_eq!(rect.top, 20.0 + f64::from(y) * 0.5);
+        assert_eq!(rect.width, f64::from(width) * 0.5);
+        assert_eq!(rect.height, f64::from(height) * 0.5);
+        assert!(rect.width > 0.0 && rect.height > 0.0);
+    }
+}
+
+#[test]
+fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
+    use super::*;
+    use crate::editor::tests::{TimelineTestExt, lock_gstreamer_test, ulid};
+    use ges::prelude::*;
+    use gstreamer as gst;
+    use gstreamer_editing_services as ges;
+    let _guard = lock_gstreamer_test();
+    ges::init().unwrap();
+    let mut data = TimelineSerialization::with_test_tracks();
+    data.settings.width = 640;
+    data.settings.height = 360;
+    let id = ulid(920);
+    data.tracks.push(Track {
+        id,
+        name: "Text".into(),
+        kind: TrackKind::Text,
+        locked: true,
+        muted: false,
+        visible: true,
+    });
+    let clip_id = ulid(921);
+    data.clips.push(Clip::Text(TextClip {
+        id: clip_id,
+        track_id: id,
+        timeline_start: TimelineTime::ZERO,
+        length: Duration::from_secs(2),
+        properties: TextClipProperties::default(),
+    }));
+    let timeline = export_gstreamer::build_ges_timeline(
+        &data,
+        std::path::Path::new("."),
+        export::ExportOptions::from_timeline(&data),
+        false,
+    )
+    .unwrap();
+    let canvas = TimelinePreviewCanvas {
+        left: 20.0,
+        top: 10.0,
+        width: 320.0,
+        height: 180.0,
+        project_scale: 0.5,
+    };
+    assert!(timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas).is_empty());
+    let pipeline = ges::Pipeline::new();
+    pipeline.preview_set_video_sink(Some(
+        &gst::ElementFactory::make("fakesink").build().unwrap(),
+    ));
+    pipeline.preview_set_audio_sink(Some(
+        &gst::ElementFactory::make("fakesink").build().unwrap(),
+    ));
+    pipeline.set_timeline(&timeline).unwrap();
+    pipeline.set_mode(ges::PipelineFlags::FULL_PREVIEW).unwrap();
+    pipeline.set_state(gst::State::Paused).unwrap();
+    let ready = pipeline.state(gst::ClockTime::from_seconds(5));
+    let rects = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    let end = data.clips[0].timeline_end(data.settings.frame_rate);
+    let ended = timeline_preview_clip_rects(&data, &timeline, end, canvas);
+    data.tracks.last_mut().unwrap().visible = false;
+    let hidden = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    data.tracks.last_mut().unwrap().visible = true;
+    let Clip::Text(text) = &mut data.clips[0] else {
+        unreachable!()
+    };
+    text.properties.text.clear();
+    let empty = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    pipeline.set_state(gst::State::Null).unwrap();
+    ready.0.unwrap();
+    assert_eq!(ready.1, gst::State::Paused);
+    assert_eq!(rects.len(), 1);
+    let rect = rects[0].1;
+    assert_eq!(
+        hit_preview_clip(
+            &rects,
+            canvas,
+            rect.left + rect.width / 2.0,
+            rect.top + rect.height / 2.0
+        ),
+        Some(clip_id)
+    );
+    assert!(ended.is_empty());
+    assert!(hidden.is_empty());
+    assert!(empty.is_empty());
+}

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -1,4 +1,5 @@
 use super::nearest_canvas_snap;
+use gpui::{Bounds, point, size};
 
 #[test]
 fn snaps_clip_centers_and_edges_to_canvas_centers_and_edges() {
@@ -24,18 +25,13 @@ fn snaps_clip_centers_and_edges_to_canvas_centers_and_edges() {
 
 #[test]
 fn resizing_each_corner_preserves_aspect_ratio_and_opposite_corner() {
-    use super::{RenderRect, VideoClipProperties, resized_preview_properties};
+    use super::{VideoClipProperties, resized_preview_properties};
     let original = VideoClipProperties {
         position_x: 20.0,
         position_y: -10.0,
         scale: 1.0,
     };
-    let rect = RenderRect {
-        left: 10.0,
-        top: 30.0,
-        width: 200.0,
-        height: 100.0,
-    };
+    let rect = Bounds::new(point(10.0, 30.0), size(200.0, 100.0));
     for corner in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
         let resized = resized_preview_properties(
             original,
@@ -48,27 +44,22 @@ fn resizing_each_corner_preserves_aspect_ratio_and_opposite_corner() {
         let center_delta_x = (resized.position_x - original.position_x) * 0.5;
         let center_delta_y = (resized.position_y - original.position_y) * 0.5;
         assert_eq!(
-            center_delta_x - corner.0 * rect.width * resized.scale / 2.0,
-            -corner.0 * rect.width / 2.0
+            center_delta_x - corner.0 * rect.size.width * resized.scale / 2.0,
+            -corner.0 * rect.size.width / 2.0
         );
         assert_eq!(
-            center_delta_y - corner.1 * rect.height * resized.scale / 2.0,
-            -corner.1 * rect.height / 2.0
+            center_delta_y - corner.1 * rect.size.height * resized.scale / 2.0,
+            -corner.1 * rect.size.height / 2.0
         );
     }
 }
 
 #[test]
 fn resizing_past_the_opposite_corner_does_not_flip_the_clip() {
-    use super::{RenderRect, VideoClipProperties, resized_preview_properties};
+    use super::{VideoClipProperties, resized_preview_properties};
     let resized = resized_preview_properties(
         VideoClipProperties::default(),
-        RenderRect {
-            left: 0.0,
-            top: 0.0,
-            width: 200.0,
-            height: 100.0,
-        },
+        Bounds::new(point(0.0, 0.0), size(200.0, 100.0)),
         (1.0, 1.0),
         (-400.0, -200.0),
         1.0,
@@ -78,15 +69,10 @@ fn resizing_past_the_opposite_corner_does_not_flip_the_clip() {
 
 #[test]
 fn resize_snaps_all_corners_without_moving_the_opposite_corner() {
-    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
+    use super::{VideoClipProperties, snap_preview_resize};
     for corner in [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)] {
-        let rect = RenderRect {
-            left: 100.0,
-            top: 100.0,
-            width: 200.0,
-            height: 100.0,
-        };
-        let fixed_x = rect.left + (1.0 - corner.0) * rect.width / 2.0;
+        let rect = Bounds::new(point(100.0, 100.0), size(200.0, 100.0));
+        let fixed_x = rect.origin.x + (1.0 - corner.0) * rect.size.width / 2.0;
         let target = fixed_x + corner.0 * 204.0;
         let (result, x, y) = snap_preview_resize(
             VideoClipProperties::default(),
@@ -106,13 +92,8 @@ fn resize_snaps_all_corners_without_moving_the_opposite_corner() {
 
 #[test]
 fn resize_snaps_centers_and_only_shows_guides_that_match_final_geometry() {
-    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
-    let rect = RenderRect {
-        left: 0.0,
-        top: 0.0,
-        width: 200.0,
-        height: 100.0,
-    };
+    use super::{VideoClipProperties, snap_preview_resize};
+    let rect = Bounds::new(point(0.0, 0.0), size(200.0, 100.0));
     // Snap the clip center to x=102, which also aligns its bottom with y=102.
     let (result, x, y) = snap_preview_resize(
         VideoClipProperties::default(),
@@ -144,14 +125,9 @@ fn resize_snaps_centers_and_only_shows_guides_that_match_final_geometry() {
 #[test]
 fn preview_does_not_snap_five_pixels_away() {
     assert_eq!(nearest_canvas_snap([5.0, 15.0, 25.0], &[0.0]), None);
-    use super::{RenderRect, VideoClipProperties, snap_preview_resize};
+    use super::{VideoClipProperties, snap_preview_resize};
     let properties = VideoClipProperties::default();
-    let rect = RenderRect {
-        left: 0.0,
-        top: 0.0,
-        width: 200.0,
-        height: 100.0,
-    };
+    let rect = Bounds::new(point(0.0, 0.0), size(200.0, 100.0));
     assert_eq!(
         snap_preview_resize(properties, rect, (1.0, 1.0), 1.0, &[205.0], &[]),
         (properties, None, None)
@@ -160,41 +136,33 @@ fn preview_does_not_snap_five_pixels_away() {
 
 #[test]
 fn hit_testing_uses_frontmost_rectangle_and_excludes_letterboxing() {
-    use super::{RenderRect, TimelinePreviewCanvas, hit_preview_clip};
+    use super::{TimelinePreviewCanvas, hit_preview_clip};
     let canvas = TimelinePreviewCanvas {
-        left: 100.0,
-        top: 50.0,
-        width: 400.0,
-        height: 200.0,
+        bounds: Bounds::new(point(100.0, 50.0), size(400.0, 200.0)),
         project_scale: 0.5,
     };
     let front = super::Ulid::from(1_u128);
     let back = super::Ulid::from(2_u128);
     let rects = [
-        (
-            front,
-            RenderRect {
-                left: 120.0,
-                top: 60.0,
-                width: 80.0,
-                height: 30.0,
-            },
-        ),
-        (
-            back,
-            RenderRect {
-                left: 0.0,
-                top: 0.0,
-                width: 600.0,
-                height: 400.0,
-            },
-        ),
+        (front, Bounds::new(point(120.0, 60.0), size(80.0, 30.0))),
+        (back, Bounds::new(point(0.0, 0.0), size(600.0, 400.0))),
     ];
     assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 70.0), Some(front));
+    assert_eq!(hit_preview_clip(&rects, canvas, 200.0, 90.0), Some(front));
+    assert_eq!(hit_preview_clip(&rects, canvas, 500.0, 250.0), Some(back));
     assert_eq!(hit_preview_clip(&rects, canvas, 300.0, 150.0), Some(back));
     assert_eq!(hit_preview_clip(&rects, canvas, 30.0, 70.0), None);
     assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 20.0), None);
     assert_eq!(hit_preview_clip(&[], canvas, 140.0, 70.0), None);
+    assert_eq!(
+        hit_preview_clip(
+            &[(front, Bounds::new(point(500.0, 60.0), size(20.0, 30.0)))],
+            canvas,
+            500.0,
+            70.0,
+        ),
+        None,
+    );
 }
 
 #[test]
@@ -211,10 +179,7 @@ fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
         let overlay = pipeline.by_name("title").unwrap();
         overlay.set_property("text", text);
         let canvas = TimelinePreviewCanvas {
-            left: 70.0,
-            top: 20.0,
-            width: 320.0,
-            height: 180.0,
+            bounds: Bounds::new(point(70.0, 20.0), size(320.0, 180.0)),
             project_scale: 0.5,
         };
         assert!(rendered_text_rect(overlay.upcast_ref(), canvas).is_none());
@@ -232,11 +197,11 @@ fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
             continue;
         }
         let rect = rect.expect("rendered text has bounds");
-        assert_eq!(rect.left, 70.0 + f64::from(x) * 0.5);
-        assert_eq!(rect.top, 20.0 + f64::from(y) * 0.5);
-        assert_eq!(rect.width, f64::from(width) * 0.5);
-        assert_eq!(rect.height, f64::from(height) * 0.5);
-        assert!(rect.width > 0.0 && rect.height > 0.0);
+        assert_eq!(rect.origin.x, 70.0 + f64::from(x) * 0.5);
+        assert_eq!(rect.origin.y, 20.0 + f64::from(y) * 0.5);
+        assert_eq!(rect.size.width, f64::from(width) * 0.5);
+        assert_eq!(rect.size.height, f64::from(height) * 0.5);
+        assert!(rect.size.width > 0.0 && rect.size.height > 0.0);
     }
 }
 
@@ -277,10 +242,7 @@ fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
     )
     .unwrap();
     let canvas = TimelinePreviewCanvas {
-        left: 20.0,
-        top: 10.0,
-        width: 320.0,
-        height: 180.0,
+        bounds: Bounds::new(point(20.0, 10.0), size(320.0, 180.0)),
         project_scale: 0.5,
     };
     assert!(timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas).is_empty());
@@ -315,8 +277,8 @@ fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
         hit_preview_clip(
             &rects,
             canvas,
-            rect.left + rect.width / 2.0,
-            rect.top + rect.height / 2.0
+            rect.origin.x + rect.size.width / 2.0,
+            rect.origin.y + rect.size.height / 2.0
         ),
         Some(clip_id)
     );

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -170,7 +170,6 @@ fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
     use super::{TimelinePreviewCanvas, rendered_text_rect};
     use gst::prelude::*;
     use gstreamer as gst;
-    let _guard = crate::editor::tests::lock_gstreamer_test();
     gst::init().unwrap();
     for text in ["Title", "Two\nlines", "你好 世界", ""] {
         let pipeline = gst::parse::launch(
@@ -208,11 +207,10 @@ fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
 #[test]
 fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
     use super::*;
-    use crate::editor::tests::{TimelineTestExt, lock_gstreamer_test, ulid};
+    use crate::editor::tests::{TimelineTestExt, ulid};
     use ges::prelude::*;
     use gstreamer as gst;
     use gstreamer_editing_services as ges;
-    let _guard = lock_gstreamer_test();
     ges::init().unwrap();
     let mut data = TimelineSerialization::with_test_tracks();
     data.settings.width = 640;

--- a/rust/src/editor/tests/preview_timeline.test.rs
+++ b/rust/src/editor/tests/preview_timeline.test.rs
@@ -147,17 +147,17 @@ fn hit_testing_uses_frontmost_rectangle_and_excludes_letterboxing() {
         (front, Bounds::new(point(120.0, 60.0), size(80.0, 30.0))),
         (back, Bounds::new(point(0.0, 0.0), size(600.0, 400.0))),
     ];
-    assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 70.0), Some(front));
-    assert_eq!(hit_preview_clip(&rects, canvas, 200.0, 90.0), Some(front));
-    assert_eq!(hit_preview_clip(&rects, canvas, 500.0, 250.0), Some(back));
-    assert_eq!(hit_preview_clip(&rects, canvas, 300.0, 150.0), Some(back));
-    assert_eq!(hit_preview_clip(&rects, canvas, 30.0, 70.0), None);
-    assert_eq!(hit_preview_clip(&rects, canvas, 140.0, 20.0), None);
-    assert_eq!(hit_preview_clip(&[], canvas, 140.0, 70.0), None);
+    assert_eq!(hit_preview_clip(&rects, &canvas, 140.0, 70.0), Some(front));
+    assert_eq!(hit_preview_clip(&rects, &canvas, 200.0, 90.0), Some(front));
+    assert_eq!(hit_preview_clip(&rects, &canvas, 500.0, 250.0), Some(back));
+    assert_eq!(hit_preview_clip(&rects, &canvas, 300.0, 150.0), Some(back));
+    assert_eq!(hit_preview_clip(&rects, &canvas, 30.0, 70.0), None);
+    assert_eq!(hit_preview_clip(&rects, &canvas, 140.0, 20.0), None);
+    assert_eq!(hit_preview_clip(&[], &canvas, 140.0, 70.0), None);
     assert_eq!(
         hit_preview_clip(
             &[(front, Bounds::new(point(500.0, 60.0), size(20.0, 30.0)))],
-            canvas,
+            &canvas,
             500.0,
             70.0,
         ),
@@ -182,10 +182,10 @@ fn rendered_text_bounds_follow_real_pixels_and_preview_scaling() {
             bounds: Bounds::new(point(70.0, 20.0), size(320.0, 180.0)),
             project_scale: 0.5,
         };
-        assert!(rendered_text_rect(overlay.upcast_ref(), canvas).is_none());
+        assert!(rendered_text_rect(overlay.upcast_ref(), &canvas).is_none());
         pipeline.set_state(gst::State::Paused).unwrap();
         let ready = pipeline.state(gst::ClockTime::from_seconds(5));
-        let rect = rendered_text_rect(overlay.upcast_ref(), canvas);
+        let rect = rendered_text_rect(overlay.upcast_ref(), &canvas);
         let x = overlay.property::<i32>("text-x");
         let y = overlay.property::<i32>("text-y");
         let width = overlay.property::<u32>("text-width");
@@ -245,7 +245,7 @@ fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
         bounds: Bounds::new(point(20.0, 10.0), size(320.0, 180.0)),
         project_scale: 0.5,
     };
-    assert!(timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas).is_empty());
+    assert!(timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, &canvas).is_empty());
     let pipeline = ges::Pipeline::new();
     pipeline.preview_set_video_sink(Some(
         &gst::ElementFactory::make("fakesink").build().unwrap(),
@@ -257,17 +257,17 @@ fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
     pipeline.set_mode(ges::PipelineFlags::FULL_PREVIEW).unwrap();
     pipeline.set_state(gst::State::Paused).unwrap();
     let ready = pipeline.state(gst::ClockTime::from_seconds(5));
-    let rects = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    let rects = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, &canvas);
     let end = data.clips[0].timeline_end(data.settings.frame_rate);
-    let ended = timeline_preview_clip_rects(&data, &timeline, end, canvas);
+    let ended = timeline_preview_clip_rects(&data, &timeline, end, &canvas);
     data.tracks.last_mut().unwrap().visible = false;
-    let hidden = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    let hidden = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, &canvas);
     data.tracks.last_mut().unwrap().visible = true;
     let Clip::Text(text) = &mut data.clips[0] else {
         unreachable!()
     };
     text.properties.text.clear();
-    let empty = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, canvas);
+    let empty = timeline_preview_clip_rects(&data, &timeline, TimelineTime::ZERO, &canvas);
     pipeline.set_state(gst::State::Null).unwrap();
     ready.0.unwrap();
     assert_eq!(ready.1, gst::State::Paused);
@@ -276,7 +276,7 @@ fn ges_text_rectangles_respect_visibility_time_and_locked_selection() {
     assert_eq!(
         hit_preview_clip(
             &rects,
-            canvas,
+            &canvas,
             rect.origin.x + rect.size.width / 2.0,
             rect.origin.y + rect.size.height / 2.0
         ),

--- a/rust/src/editor/tests/shared_timeline.test.rs
+++ b/rust/src/editor/tests/shared_timeline.test.rs
@@ -1,4 +1,4 @@
-use super::super::{FrameRate, TimelineEditorExt, TimelineTime, tests, timeline_document};
+use super::super::{FrameRate, TimelineEditorExt, TimelineTime, timeline_document};
 use super::*;
 use gst_pbutils::prelude::*;
 use image::{Rgba, RgbaImage};
@@ -16,7 +16,6 @@ use std::fs;
 
 #[test]
 fn shared_timeline_round_trip_and_backend_rendering() {
-    let _lock = tests::lock_gstreamer_test();
     ges::init().unwrap();
     let root = std::env::temp_dir().join(format!("opencut-shared-{}", Ulid::generate()));
     fs::create_dir_all(root.join("media")).unwrap();
@@ -182,7 +181,6 @@ fn shared_timeline_round_trip_and_backend_rendering() {
 
 #[test]
 fn shared_timeline_podcast_assembly_exports_in_both_backends() {
-    let _lock = tests::lock_gstreamer_test();
     ges::init().unwrap();
     let root = std::env::temp_dir().join(format!("opencut-podcast-{}", Ulid::generate()));
     fs::create_dir(&root).unwrap();

--- a/rust/src/editor/tests/timeline_audio.test.rs
+++ b/rust/src/editor/tests/timeline_audio.test.rs
@@ -1,10 +1,9 @@
 use super::*;
-use crate::editor::tests::{TimelineTestExt, lock_gstreamer_test};
+use crate::editor::tests::TimelineTestExt;
 use crate::editor::timeline_clip::{AudioClipProperties, VideoClip};
 
 #[test]
 fn renders_trimmed_audio_with_gaps_gain_and_no_output_files() {
-    let _lock = lock_gstreamer_test();
     let root = std::env::temp_dir().join(format!("opencut-audio-{}", Ulid::generate()));
     std::fs::create_dir(&root).unwrap();
     let mut input = vec![0; 44];
@@ -139,7 +138,6 @@ fn renders_trimmed_audio_with_gaps_gain_and_no_output_files() {
 
 #[test]
 fn renders_video_audio_without_video_tracks() {
-    let _lock = lock_gstreamer_test();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let relative = PathBuf::from("data/tests/mini测试/地铁-出站-mini-480.mp4");
     let mut asset = media_probe::probe_asset(&root.join(&relative)).unwrap();

--- a/rust/src/editor/tests/timeline_video.test.rs
+++ b/rust/src/editor/tests/timeline_video.test.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn repeated_drag_refreshes_allow_slow_frames_to_finish() {
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     ges::init().unwrap();
     let pipeline = gst::parse::launch(
         "videotestsrc name=source pattern=black num-buffers=300 ! video/x-raw,format=RGBA,width=16,height=16,framerate=30/1 ! identity sleep-time=50000 ! appsink name=sink",
@@ -44,7 +43,6 @@ fn repeated_drag_refreshes_allow_slow_frames_to_finish() {
 
 #[test]
 fn playback_resumes_after_repeated_resize_refreshes() {
-    let _gstreamer_test = crate::editor::tests::lock_gstreamer_test();
     ges::init().unwrap();
     let timeline = ges::Timeline::new_audio_video();
     let clip = ges::TestClip::new().unwrap();
@@ -85,5 +83,86 @@ fn playback_resumes_after_repeated_resize_refreshes() {
         }
         playback.set_paused(true);
         pipeline.state(gst::ClockTime::from_seconds(5)).0.unwrap();
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn hevc_with_title_boundaries_uses_software_decoding() {
+    use crate::editor::{
+        export::ExportOptions,
+        export_gstreamer::build_ges_timeline,
+        media_probe::probe_video,
+        timeline::{TimelineSerialization, TimelineTime},
+    };
+    ges::init().unwrap();
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("data/tests");
+    let asset_id = ulid::Ulid::generate();
+    let mut asset = probe_video(&root.join("4K.MOV"), asset_id).unwrap();
+    asset.path = "4K.MOV".into();
+    let mut data: TimelineSerialization = serde_json::from_value(serde_json::json!({
+        "settings": {"frame_rate":{"numerator":24000,"denominator":1001},"width":320,"height":180,"audio_sample_rate":48000},
+        "assets": [asset],
+        "tracks": [
+            {"id":"01M0PNQ7A7CTYF1YA8J2T5PQW5","name":"Video","kind":"Video","locked":false,"muted":false,"visible":true},
+            {"id":"01M10SFVCR94J5XPK9WSXSA3X0","name":"Text","kind":"Text","locked":false,"muted":false,"visible":true},
+            {"id":"01M2CXTP09K0KD0VBMEB9T2J4Z","name":"Text 2","kind":"Text","locked":false,"muted":false,"visible":true}
+        ],
+        "clips": []
+    })).unwrap();
+    data.clips.push(
+        serde_json::from_value(serde_json::json!({"kind":"Video","data":{
+            "id":"01M1BDHHMW2HQMDWQWJGVYKW8H","track_id":data.tracks[0].id,"asset_id":asset_id,
+            "timeline_start":0,"source_in":0,"source_out":56,
+            "video_properties":{"position_x":0.0,"position_y":0.0,"scale":1.0},
+            "audio_properties":{"gain_db":0.0,"muted":false}
+        }}))
+        .unwrap(),
+    );
+    for (index, start, nanos) in [(1, 4, 1_500_000_000_u64), (2, 30, 140_000_000)] {
+        data.clips.push(serde_json::from_value(serde_json::json!({"kind":"Text","data":{
+            "id":ulid::Ulid::generate(),"track_id":data.tracks[index].id,"timeline_start":start,
+            "length":{"secs":nanos/1_000_000_000,"nanos":nanos%1_000_000_000},
+            "properties":{"text":"Title","font":"Sans","font_size":20.0,"color":4294967295_u32,"position_x":0.5,"position_y":0.5}
+        }})).unwrap());
+    }
+    let timeline =
+        build_ges_timeline(&data, &root, ExportOptions::from_timeline(&data), false).unwrap();
+    let mut backend = TimelineVideoBackend::new(timeline).unwrap();
+    let playback = backend.playback_mut();
+    playback
+        .pipeline()
+        .state(gst::ClockTime::from_seconds(10))
+        .0
+        .unwrap();
+    let mut software_decoder = false;
+    let mut elements = playback.pipeline().iterate_recurse();
+    while let Ok(Some(element)) = elements.next() {
+        if let Some(factory) = element.factory() {
+            software_decoder |= factory.name() == "avdec_h265";
+            assert!(!matches!(factory.name().as_str(), "vtdec" | "vtdec_hw"));
+        }
+    }
+    assert!(
+        software_decoder,
+        "HEVC title timeline must use the software decoder"
+    );
+    for frame in [26, 27, 28, 29, 30, 31, 30, 29, 28, 27] {
+        playback
+            .seek(data.duration(TimelineTime::from_frames(frame)))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        playback
+            .pipeline()
+            .state(gst::ClockTime::from_seconds(10))
+            .0
+            .unwrap();
+        let sample = playback.get_current_frame().unwrap();
+        let pixels = sample.buffer().unwrap().map_readable().unwrap();
+        let visible = pixels.as_slice()[..320 * 180]
+            .iter()
+            .filter(|&&value| value > 32)
+            .count();
+        assert!(visible > 320 * 180 / 10, "video missing at frame {frame}");
     }
 }

--- a/rust/src/gpui_inspector.rs
+++ b/rust/src/gpui_inspector.rs
@@ -182,6 +182,29 @@ fn render_inspector(
                 .gap_3()
                 .p_3()
                 .child(render_fps_section(render_fps))
+                .child(
+                    div()
+                        .id("gpui-inspector-dump-debug-state")
+                        .h_8()
+                        .px_3()
+                        .flex()
+                        .items_center()
+                        .rounded_md()
+                        .border_1()
+                        .border_color(rgb(BORDER))
+                        .bg(rgb(SURFACE))
+                        .hover(|style| style.bg(rgb(SURFACE_HOVER)))
+                        .cursor(CursorStyle::Arrow)
+                        .text_sm()
+                        .child("Dump debug state (copy)")
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_click(|_, window, cx| {
+                            let Some(Some(editor)) = window.root::<crate::editor::Editor>() else {
+                                return;
+                            };
+                            editor.update(cx, |editor, cx| editor.copy_debug_state(cx));
+                        }),
+                )
                 .when_some(selected, |this, id| this.child(render_element_id(&id)))
                 .when(states.is_empty(), |this| {
                     this.child(

--- a/rust/tests/cli.rs
+++ b/rust/tests/cli.rs
@@ -755,7 +755,10 @@ impl Drop for Temp {
 
 #[test]
 fn generates_agent_docs_from_cli_definitions() {
-    let output = Command::new(env!("CARGO_BIN_EXE_opencut")).args(["doc"]).output().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_opencut"))
+        .args(["doc"])
+        .output()
+        .unwrap();
     assert!(output.status.success());
     let text = String::from_utf8(output.stdout).unwrap();
     assert!(text.contains("## Recommended workflow"));
@@ -763,7 +766,16 @@ fn generates_agent_docs_from_cli_definitions() {
     assert!(!text.contains("--llm"));
     assert!(text.contains("--post-merge"));
     assert!(text.contains("--project-root"));
-    let json_output = Command::new(env!("CARGO_BIN_EXE_opencut")).args(["docs", "--json"]).output().unwrap();
+    let json_output = Command::new(env!("CARGO_BIN_EXE_opencut"))
+        .args(["docs", "--json"])
+        .output()
+        .unwrap();
     assert!(json_output.status.success());
-    assert_eq!(serde_json::from_slice::<Value>(&json_output.stdout).unwrap().as_str().unwrap(), text.strip_suffix('\n').unwrap());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&json_output.stdout)
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        text.strip_suffix('\n').unwrap()
+    );
 }

--- a/rust/todo.md
+++ b/rust/todo.md
@@ -88,3 +88,40 @@
      [timeline.test.rs](/Users/mac/Documents/GitHub/OpenCut/rust/src/editor/tests/timeline.test.rs:36)
      and verify startup/switch restoration at a nonzero frame, fractional frame
      rates, empty timelines, and a saved position beyond shortened content.
+
+- [ ] **Text manipulation in the preview — implement stages in order.**
+
+  Extend existing preview interactions to text, sharing renderer-derived bounds
+  between hit detection, selection outlines, and eventual snapping. Preserve the
+  serialized text format and existing media interactions.
+  Location: [preview_timeline.rs](/Users/mac/Documents/GitHub/OpenCut/rust/src/editor/preview_timeline.rs:10).
+
+  1. **Stage 1 — Resolve text geometry (implemented).** Read actual rendered bounds from the
+     GStreamer title overlay; convert to preview coordinates with canvas scaling
+     and letterboxing. Avoid a separate geometry cache. Exclude hidden, inactive,
+     and empty text; wait for rendered dimensions when no frame is ready.
+     Verify multiline, Unicode, font-size changes, and preview scaling.
+  2. **Stage 2 — Hit detection and selection outline (implemented).** Hit-test text rectangles
+     in rendering order, synchronize with timeline selection, and clear selection
+     on empty canvas clicks. Draw the accent outline for selected text, including
+     selection from the timeline. Locked text is selectable but cannot move;
+     unlocked text gets the move cursor. Do not add text resize handles.
+     Verify overlaps, hidden/locked tracks, seeking, and letterbox exclusion.
+  3. **Stage 3 — Drag and persist text position.** Extend drag data with a typed
+     text variant containing starting position and geometry. Select and move in
+     one gesture without jumping. Convert movement into normalized renderer
+     positions, handling limits and zero movement space safely. Change only the
+     current clip's position. Reuse refresh throttling, one undo entry per changed
+     drag, and save on release (including outside the preview). Clear unavailable
+     drag targets. Complete the stale text-input snapshot fix above so subsequent
+     typing cannot restore old positions. Verify movement, undo/redo, save/reopen,
+     typing after dragging, and no history entry for an unchanged click.
+  4. **Stage 4 — Snapping and regressions.** Reuse the snapping toggle and four
+     preview-pixel threshold. Snap edges/centers to canvas and other visible active
+     text/media clips; include text as a media snapping target. Snap each axis
+     independently and show only guides matching final alignment. Clear guides on
+     release. Verify enabled/disabled snapping, threshold boundaries, scaling,
+     self/hidden/inactive target exclusion, and existing media movement/resizing.
+
+  **Current implementation scope:** Stages 1–2 only. Stages 3–4 remain deferred.
+  Use existing vendored libraries; no FFmpeg build or Python build steps.


### PR DESCRIPTION
Adds text hit detection using rendered bounds, blue hover outlines, and gold selection outlines. Preview interactions use an arrow cursor and GPUI geometry types. Text dragging and snapping remain deferred.

Works around black frames near text-clip boundaries by selecting software HEVC decoding for macOS GES timelines. Simplifies timeline construction and adds an inspector button to copy live diagnostic state.

Defaults `test-mac` and `test-win` to one test thread and removes the shared GStreamer test lock.